### PR TITLE
Fix floating chat geometry persistence

### DIFF
--- a/ChatSurface.qml
+++ b/ChatSurface.qml
@@ -1422,8 +1422,16 @@ Item {
       color: root.theme().bg || Color.background
       property bool everShown: false
       property bool closing: false
+      property bool closeAfterPlacement: false
       property bool placementStarted: false
+      property bool placementProcessStarted: false
+      property bool placementProcessHandled: false
+      property bool placementRecoveryPending: false
+      property bool placementRecoveryStarted: false
+      property bool placementRecoveryHandled: false
       property int placementAttempts: 0
+      property int placementRecoveryAttempts: 0
+      property var placementObservedGeometry: null
 
       function boundedWidth(value) {
         return Math.max(360, Math.min(4096,
@@ -1485,16 +1493,184 @@ Item {
 
       function requestInitialPlacement() {
         if (!pinWin.placeOnMap || pinWin.placementStarted ||
+            pinWin.closeAfterPlacement ||
             !pinWin.backingWindowVisible || pinWin.title === "OmaQ chat")
           return
         pinWin.placementStarted = true
+        pinWin.placementProcessStarted = false
+        pinWin.placementProcessHandled = false
         pinWin.placementAttempts++
+        pinWin.placementObservedGeometry = null
         root.geometryGeneration++
-        placeWindow.command = [root.floatScriptPath, "place-title", pinWin.title,
+        placeWindow.command = ["/usr/bin/timeout", "--kill-after=1s", "3s",
+          root.floatScriptPath, "place-title", pinWin.title,
           String(Math.round(pinWin.surfaceX)), String(Math.round(pinWin.surfaceY)),
           String(Math.max(360, Math.round(pinWin.surfaceWidth))),
           String(Math.max(420, Math.round(pinWin.surfaceHeight)))]
         placeWindow.running = true
+      }
+
+      function recordPlacementGeometry(raw) {
+        var text = String(raw || "")
+        var value
+        if (text.length === 0 || text.length > 2048)
+          return
+        try { value = JSON.parse(text) } catch (error) { return }
+        var monitorName = String(value.monitor || "")
+        if (String(value.title || "") !== pinWin.title || monitorName.length > 63 ||
+            /[\u0000-\u001f\u007f]/.test(monitorName) ||
+            !Number.isInteger(value.x) || !Number.isInteger(value.y) ||
+            !Number.isInteger(value.width) || !Number.isInteger(value.height) ||
+            value.x < -32768 || value.x > 32768 ||
+            value.y < -32768 || value.y > 32768 ||
+            value.width < 360 || value.width > 4096 ||
+            value.height < 420 || value.height > 4096)
+          return
+        pinWin.placementObservedGeometry = { monitor: monitorName,
+          x: value.x, y: value.y, width: value.width, height: value.height }
+      }
+
+      function requestPlacementRecovery() {
+        if (!pinWin.placeOnMap || pinWin.closing || !pinWin.visible ||
+            pinWin.placementStarted || placeWindow.running ||
+            placementRecovery.running || pinWin.placementRecoveryAttempts >= 8)
+          return
+        pinWin.placementStarted = false
+        pinWin.placementRecoveryPending = true
+        pinWin.placementRecoveryStarted = false
+        pinWin.placementRecoveryHandled = false
+        pinWin.placementRecoveryAttempts++
+        pinWin.placementObservedGeometry = null
+        placementRecovery.command = ["/usr/bin/timeout", "--kill-after=1s", "3s",
+          root.floatScriptPath, "observe-title", pinWin.title]
+        placementRecovery.running = true
+      }
+
+      function finishInitialPlacement(placementFailed) {
+        var observed = pinWin.placementObservedGeometry
+        if (!observed) {
+          if (!pinWin.placementRecoveryPending)
+            pinWin.placementRecoveryAttempts = 0
+          pinWin.requestPlacementRecovery()
+          return
+        }
+        root.geometryGeneration++
+        var index = root.cardIndex(pinWin.conversation, pinWin.directKey)
+        var values = { placeOnMap: false }
+        if (observed) {
+          values.monitor = observed.monitor
+          values.surfaceX = observed.x
+          values.surfaceY = observed.y
+          values.surfaceWidth = observed.width
+          values.surfaceHeight = observed.height
+          pinWin.desiredWidth = observed.width
+          pinWin.desiredHeight = observed.height
+          pinWin.pendingWidth = observed.width
+          pinWin.pendingHeight = observed.height
+          pinWin.localResizePending = false
+        }
+        if (index >= 0)
+          root.updateCard(index, values)
+        if (observed)
+          service.setSurface(pinWin.conversation, observed.monitor,
+            observed.x, observed.y, true, pinWin.directKey,
+            observed.width, observed.height)
+        pinWin.placementObservedGeometry = null
+        pinWin.placementRecoveryPending = false
+        placementRecoveryRetry.stop()
+        if (pinWin.closeAfterPlacement) {
+          pinWin.closeAfterPlacement = false
+          Qt.callLater(pinWin.performClose)
+        } else {
+          placementSettle.restart()
+        }
+        if (placementFailed)
+          console.warn("OmaQ: could not restore independent chat geometry; keeping current geometry")
+      }
+
+      function handlePlacementExit(code) {
+        if (!pinWin.placementStarted)
+          return
+        if (pinWin.closeAfterPlacement) {
+          pinWin.placementStarted = false
+          placementRetry.stop()
+          if (pinWin.placementObservedGeometry) {
+            pinWin.finishInitialPlacement(code !== 0)
+          } else {
+            pinWin.placementRecoveryAttempts = 0
+            pinWin.requestPlacementRecovery()
+          }
+          return
+        }
+        if (code === 0) {
+          pinWin.finishInitialPlacement(false)
+          return
+        }
+        pinWin.placementStarted = false
+        if (pinWin.placementAttempts < 12)
+          placementRetry.restart()
+        else
+          pinWin.finishInitialPlacement(true)
+      }
+
+      function performClose() {
+        if (pinWin.closing || !pinWin.modelData)
+          return
+        var conversation = String(pinWin.modelData.conversation || "")
+        var key = String(pinWin.modelData.directKey || "")
+        if (!conversation)
+          return
+        if (pinPage.inCall || pinPage.incoming)
+          pinPage.hangUp()
+        pinWin.closing = true
+        pinWin.visible = false
+        root.dismissCard(conversation, key, pinWin.surfaceWidth,
+          pinWin.surfaceHeight)
+      }
+
+      function requestClose() {
+        if (pinWin.placeOnMap || pinWin.placementStarted ||
+            pinWin.placementRecoveryPending) {
+          if (pinWin.placementRecoveryAttempts >= 8 &&
+              !pinWin.placementRecoveryPending && !pinWin.placementStarted &&
+              !placeWindow.running) {
+            pinWin.closeAfterPlacement = false
+            pinWin.performClose()
+            return
+          }
+          pinWin.closeAfterPlacement = true
+          placementRetry.stop()
+          if (!placeWindow.running && !pinWin.placementStarted) {
+            if (pinWin.placementObservedGeometry) {
+              pinWin.finishInitialPlacement(true)
+            } else {
+              pinWin.requestPlacementRecovery()
+            }
+          }
+          return
+        }
+        pinWin.performClose()
+      }
+
+      function handlePlacementRecoveryExit(code) {
+        if (!pinWin.placementRecoveryPending)
+          return
+        if (code === 0 && pinWin.placementObservedGeometry) {
+          pinWin.finishInitialPlacement(true)
+          return
+        }
+        if (pinWin.placementRecoveryAttempts < 8) {
+          placementRecoveryRetry.interval = Math.min(8000,
+            500 * Math.pow(2, pinWin.placementRecoveryAttempts - 1))
+          placementRecoveryRetry.restart()
+        } else {
+          pinWin.placementRecoveryPending = false
+          console.warn("OmaQ: could not read current chat geometry; geometry remains unchanged")
+          if (pinWin.closeAfterPlacement) {
+            pinWin.closeAfterPlacement = false
+            pinWin.performClose()
+          }
+        }
       }
 
       function applyRequestedFocus() {
@@ -1540,21 +1716,48 @@ Item {
       Process {
         id: placeWindow
         running: false
-        onExited: function(code) {
-          if (code === 0) {
-            root.geometryGeneration++
-            var index = root.cardIndex(pinWin.conversation, pinWin.directKey)
-            if (index >= 0)
-              root.updateCard(index, { placeOnMap: false })
-            placementSettle.restart()
-            return
-          }
-          pinWin.placementStarted = false
-          if (pinWin.placementAttempts < 12)
-            placementRetry.restart()
-          else
-            console.warn("OmaQ: could not restore independent chat geometry")
+        stdout: SplitParser {
+          onRead: function(line) { pinWin.recordPlacementGeometry(line) }
         }
+        onStarted: pinWin.placementProcessStarted = true
+        onExited: function(code) {
+          pinWin.placementProcessHandled = true
+          pinWin.handlePlacementExit(code)
+        }
+        onRunningChanged: {
+          if (!running && pinWin.placementStarted &&
+              !pinWin.placementProcessHandled && !pinWin.placementProcessStarted) {
+            pinWin.placementProcessHandled = true
+            pinWin.handlePlacementExit(127)
+          }
+        }
+      }
+
+      Process {
+        id: placementRecovery
+        running: false
+        stdout: SplitParser {
+          onRead: function(line) { pinWin.recordPlacementGeometry(line) }
+        }
+        onStarted: pinWin.placementRecoveryStarted = true
+        onExited: function(code) {
+          pinWin.placementRecoveryHandled = true
+          pinWin.handlePlacementRecoveryExit(code)
+        }
+        onRunningChanged: {
+          if (!running && pinWin.placementRecoveryPending &&
+              !pinWin.placementRecoveryHandled && !pinWin.placementRecoveryStarted) {
+            pinWin.placementRecoveryHandled = true
+            pinWin.handlePlacementRecoveryExit(127)
+          }
+        }
+      }
+
+      Timer {
+        id: placementRecoveryRetry
+        interval: 500
+        repeat: false
+        onTriggered: pinWin.requestPlacementRecovery()
       }
 
       Timer {
@@ -1571,6 +1774,11 @@ Item {
         onTriggered: {
           root.geometryGeneration++
           pinWin.placementStarted = false
+          if (pinWin.closeAfterPlacement) {
+            pinWin.closeAfterPlacement = false
+            pinWin.performClose()
+            return
+          }
           if (pinWin.boundedWidth(pinWin.width) !== pinWin.pendingWidth)
             pinWin.captureActualWidth()
           if (pinWin.boundedHeight(pinWin.height) !== pinWin.pendingHeight)
@@ -1600,10 +1808,27 @@ Item {
         if (root.isSurfaceOwner && !root.ownershipTeardown &&
             !pinWin.closing && pinWin.everShown && pinWin.modelData &&
             pinWin.modelData.conversation) {
-          if (pinPage.inCall || pinPage.incoming)
-            pinPage.hangUp()
-          root.dismissCard(pinWin.modelData.conversation,
-            pinWin.modelData.directKey || "", pinWin.width, pinWin.height)
+          if (pinWin.placeOnMap || pinWin.placementStarted ||
+              pinWin.placementRecoveryPending) {
+            if (pinWin.placementRecoveryAttempts >= 8 &&
+                !pinWin.placementRecoveryPending && !pinWin.placementStarted &&
+                !placeWindow.running) {
+              pinWin.closeAfterPlacement = false
+              pinWin.performClose()
+              return
+            }
+            pinWin.closeAfterPlacement = true
+            placementRetry.stop()
+            pinWin.visible = true
+            if (!placeWindow.running && !pinWin.placementStarted) {
+              if (pinWin.placementObservedGeometry)
+                pinWin.finishInitialPlacement(true)
+              else
+                Qt.callLater(pinWin.requestPlacementRecovery)
+            }
+            return
+          }
+          pinWin.performClose()
         }
       }
 
@@ -1645,15 +1870,7 @@ Item {
           SurfaceBtn {
             text: "Close"
             helpText: "Close chat"
-            onClicked: {
-              var conv = String(pinWin.modelData.conversation)
-              if (pinPage.inCall || pinPage.incoming)
-                pinPage.hangUp()
-              pinWin.closing = true
-              pinWin.visible = false
-              root.dismissCard(conv, pinWin.modelData.directKey || "",
-                pinWin.width, pinWin.height)
-            }
+            onClicked: pinWin.requestClose()
           }
         }
 

--- a/scripts/float-omaq.sh
+++ b/scripts/float-omaq.sh
@@ -134,6 +134,39 @@ install_rules || exit 1
 [[ "$MODE" == "install-rules" ]] && exit 0
 command -v jq >/dev/null 2>&1 || exit 3
 
+observe_title_geometry() {
+  local clients monitors placement
+  clients=$(hyprctl -j clients 2>/dev/null) || return 1
+  monitors=$(hyprctl -j monitors 2>/dev/null) || return 1
+  (( ${#clients} <= 1048576 && ${#monitors} <= 262144 )) || return 1
+  placement=$(jq -cn --arg title "$TARGET_TITLE" --argjson clients "$clients" \
+    --argjson monitors "$monitors" '
+    [$clients[] | select((.title // "") == $title)] as $matches |
+    if ($matches | length) == 1 and ($matches[0].floating // false) == true and
+       (($matches[0].address // "") | test("^0x[0-9a-fA-F]+$")) and
+       (($matches[0].at // []) | length) == 2 and
+       (($matches[0].size // []) | length) == 2
+    then $matches[0] as $client |
+      {title: $title, address: $client.address, x: $client.at[0], y: $client.at[1],
+       width: $client.size[0], height: $client.size[1],
+       monitor: (($monitors[] | select(.id == $client.monitor) | .name) // "")}
+    else empty end') || return 1
+  (( ${#placement} > 0 && ${#placement} <= 2048 )) || return 1
+  printf '%s\n' "$placement"
+}
+
+emit_title_geometry() {
+  local placement
+  placement=$(observe_title_geometry) || return 1
+  jq -c 'del(.address)' <<<"$placement" || return 1
+}
+
+if [[ "$MODE" == "observe-title" ]]; then
+  [[ -n "$TARGET_TITLE" ]] || exit 2
+  emit_title_geometry || exit 3
+  exit 0
+fi
+
 if [[ "$MODE" == "place-title" ]]; then
   [[ -n "$TARGET_TITLE" && "$TARGET_X" =~ ^-?[0-9]+$ &&
      "$TARGET_Y" =~ ^-?[0-9]+$ && "$TARGET_WIDTH" =~ ^[0-9]+$ &&
@@ -142,16 +175,35 @@ if [[ "$MODE" == "place-title" ]]; then
      TARGET_Y >= -32768 && TARGET_Y <= 32768 &&
      TARGET_WIDTH >= 360 && TARGET_WIDTH <= 4096 &&
      TARGET_HEIGHT >= 420 && TARGET_HEIGHT <= 4096 )) || exit 2
-  client=$(hyprctl -j clients 2>/dev/null | jq -r --arg title "$TARGET_TITLE" '
-    [.[] | select((.title // "") == $title)] |
-    if length == 1 and (.[0].floating // false) == true and
-       ((.[0].address // "") | test("^0x[0-9a-fA-F]+$"))
-    then .[0].address else empty end')
+  placement=$(observe_title_geometry) || exit 3
+  client=$(jq -r '.address // empty' <<<"$placement")
   [[ "$client" =~ ^0x[0-9a-fA-F]+$ ]] || exit 3
-  hyprctl dispatch "resizewindowpixel" \
-    "exact ${TARGET_WIDTH} ${TARGET_HEIGHT},address:${client}" >/dev/null || exit 4
-  hyprctl dispatch "movewindowpixel" \
-    "exact ${TARGET_X} ${TARGET_Y},address:${client}" >/dev/null || exit 4
+  if (( LUA )); then
+    if ! hyprctl dispatch \
+      "hl.dsp.window.resize({ x = ${TARGET_WIDTH}, y = ${TARGET_HEIGHT}, relative = false, window = \"address:${client}\" })" \
+      >/dev/null; then
+      emit_title_geometry || true
+      exit 4
+    fi
+    if ! hyprctl dispatch \
+      "hl.dsp.window.move({ x = ${TARGET_X}, y = ${TARGET_Y}, relative = false, window = \"address:${client}\" })" \
+      >/dev/null; then
+      emit_title_geometry || true
+      exit 4
+    fi
+  else
+    if ! hyprctl dispatch "resizewindowpixel" \
+      "exact ${TARGET_WIDTH} ${TARGET_HEIGHT},address:${client}" >/dev/null; then
+      emit_title_geometry || true
+      exit 4
+    fi
+    if ! hyprctl dispatch "movewindowpixel" \
+      "exact ${TARGET_X} ${TARGET_Y},address:${client}" >/dev/null; then
+      emit_title_geometry || true
+      exit 4
+    fi
+  fi
+  emit_title_geometry || exit 3
   exit 0
 fi
 

--- a/tests/chat-surface-geometry.sh
+++ b/tests/chat-surface-geometry.sh
@@ -28,7 +28,7 @@ required = (
     "function cardMonitorCollides(cardMonitor, targetMonitor)",
     "function surfaceRectanglesOverlap(x, y, width, height, card)",
     "function initialGeometry(monitor, preferredWidth, preferredHeight)",
-    'placeWindow.command = [root.floatScriptPath, "place-title", pinWin.title,',
+    'root.floatScriptPath, "place-title", pinWin.title,',
     'command: [root.floatScriptPath, "list-geometry"]',
     'function applyGeometrySnapshot(raw)',
     "property int geometryGeneration: 0",
@@ -51,6 +51,28 @@ required = (
     "pinWin.pendingWidth,",
     "pinWin.localResizePending = false",
     "if (pinWin.placementAttempts < 12)",
+    "property var placementObservedGeometry: null",
+    "property bool placementRecoveryPending: false",
+    "function recordPlacementGeometry(raw)",
+    "function requestPlacementRecovery()",
+    "function finishInitialPlacement(placementFailed)",
+    '"/usr/bin/timeout", "--kill-after=1s", "3s"',
+    'root.floatScriptPath, "observe-title", pinWin.title',
+    "property bool placementProcessStarted: false",
+    "property bool placementProcessHandled: false",
+    "property int placementRecoveryAttempts: 0",
+    "pinWin.placementRecoveryAttempts >= 8",
+    "pinWin.placementRecoveryAttempts < 8",
+    "function handlePlacementExit(code)",
+    "function handlePlacementRecoveryExit(code)",
+    "function requestClose()",
+    "pinWin.placementStarted || placeWindow.running",
+    "onClicked: pinWin.requestClose()",
+    "pinWin.visible = true",
+    "stdout: SplitParser {",
+    "root.updateCard(index, values)",
+    "pinWin.finishInitialPlacement(true)",
+    "pinWin.finishInitialPlacement(false)",
     'service.setSurface(String(current.conversation || ""),',
     "pinned: keepExplicitlyOpen ? true : !!saved.pinned",
     "explicitOpen: true",
@@ -60,12 +82,53 @@ required = (
 for value in required:
     if value not in text:
         raise SystemExit(f"chat-surface-geometry: missing keyed geometry guard: {value}")
-for forbidden in ("openCards = next", "openCards = filtered", "root.openCards = []"):
+for forbidden in ("openCards = next", "openCards = filtered", "root.openCards = []",
+                  "placeWindow.signal(", "placementRecovery.signal("):
     if forbidden in text:
         raise SystemExit(f"chat-surface-geometry: array model reset returned: {forbidden}")
 remove = text[text.index("function dismissCard"):text.index("function pin(")]
 if remove.index("var removedKey") > remove.index("openCardModel.remove(index)"):
     raise SystemExit("chat-surface-geometry: geometry snapshot occurs after model removal")
+finish = text[text.index("function finishInitialPlacement(placementFailed)"):
+              text.index("function applyRequestedFocus()")]
+for value in ("values.surfaceX = observed.x", "values.surfaceY = observed.y",
+              "service.setSurface(pinWin.conversation, observed.monitor"):
+    if value not in finish:
+        raise SystemExit(f"chat-surface-geometry: failed placement loses actual geometry: {value}")
+handler = text[text.index("function handlePlacementExit(code)"):
+               text.index("function performClose()")]
+for value in ("if (pinWin.closeAfterPlacement)",
+              "pinWin.requestPlacementRecovery()"):
+    if value not in handler:
+        raise SystemExit(f"chat-surface-geometry: failed placement strands close: {value}")
+recovery = text[text.index("function handlePlacementRecoveryExit(code)"):
+                text.index("function applyRequestedFocus()")]
+if recovery.count("pinWin.performClose()") != 1:
+    raise SystemExit("chat-surface-geometry: exhausted close recovery remains stuck")
+settle = text[text.index("id: placementSettle"):
+              text.index("id: geometrySave")]
+if "pinWin.performClose()" not in settle:
+    raise SystemExit("chat-surface-geometry: settlement strands deferred close")
+close = text[text.index("function performClose()"):
+             text.index("function requestClose()")]
+for value in ("pinWin.surfaceWidth", "pinWin.surfaceHeight"):
+    if value not in close:
+        raise SystemExit(f"chat-surface-geometry: deferred close loses observed size: {value}")
+request_close = text[text.index("function requestClose()"):
+                     text.index("function handlePlacementRecoveryExit(code)")]
+request_exhausted = request_close.index("pinWin.placementRecoveryAttempts >= 8")
+if (request_exhausted > request_close.index("pinWin.closeAfterPlacement = true") or
+        "pinWin.closeAfterPlacement = false" not in request_close[request_exhausted:] or
+        "pinWin.performClose()" not in request_close[request_exhausted:]):
+    raise SystemExit("chat-surface-geometry: explicit exhausted close starts recovery")
+visible_start = text.index("onVisibleChanged: {", text.index("id: geometrySave"))
+visible_close = text[visible_start:text.index("FocusScope {", visible_start)]
+visible_exhausted = visible_close.index("pinWin.placementRecoveryAttempts >= 8")
+if (visible_exhausted > visible_close.index("pinWin.closeAfterPlacement = true") or
+        visible_exhausted > visible_close.index("pinWin.visible = true") or
+        "pinWin.closeAfterPlacement = false" not in visible_close[visible_exhausted:] or
+        "pinWin.performClose()" not in visible_close[visible_exhausted:]):
+    raise SystemExit("chat-surface-geometry: compositor exhausted close remaps window")
 PY
 cat >"$tmp/shell.qml" <<'QML'
 import QtQuick
@@ -79,11 +142,23 @@ ShellRoot {
   }
   ListModel {
     id: resizeCards
-    ListElement { conversation: "7"; surfaceWidth: 420; surfaceHeight: 420 }
     ListElement {
-      conversation: "g:0000000000000000000000000000000000000000000000000000000000000000"
+      conversation: "7"
+      monitor: "DP-1"
+      surfaceX: 40
+      surfaceY: 80
       surfaceWidth: 420
       surfaceHeight: 420
+      placeOnMap: false
+    }
+    ListElement {
+      conversation: "g:0000000000000000000000000000000000000000000000000000000000000000"
+      monitor: "DP-1"
+      surfaceX: 488
+      surfaceY: 80
+      surfaceWidth: 420
+      surfaceHeight: 420
+      placeOnMap: false
     }
   }
   property var survivor: null
@@ -93,6 +168,8 @@ ShellRoot {
   property int geometryGeneration: 0
   property int staleSnapshotGeneration: -1
   property bool pendingSnapshotRejected: false
+  property var persistedRecovery: null
+  property bool closedAfterRecovery: false
 
   function applyDelayedSnapshot(generation, target, width, height) {
     if (generation !== geometryGeneration)
@@ -195,14 +272,23 @@ ShellRoot {
       id: resizeDelegate
       required property int index
       required property string conversation
+      required property string monitor
+      required property real surfaceX
+      required property real surfaceY
       required property real surfaceWidth
       required property real surfaceHeight
+      required property bool placeOnMap
       property int desiredWidth: surfaceWidth
       property int desiredHeight: surfaceHeight
       property int pendingWidth: surfaceWidth
       property int pendingHeight: surfaceHeight
       property bool localResizePending: false
       property bool placementStarted: false
+      property bool closeAfterPlacement: false
+      property bool placementRecoveryPending: false
+      property int placementRecoveryAttempts: 0
+      property var placementObservedGeometry: null
+      readonly property string title: conversation.charAt(0) === "g" ? "Group" : "Direct"
 
       function syncDesiredWidth() {
         if (localResizePending && surfaceWidth !== pendingWidth)
@@ -228,6 +314,71 @@ ShellRoot {
         resizeCards.setProperty(index, "surfaceWidth", actualWidth)
         resizeCards.setProperty(index, "surfaceHeight", actualHeight)
         geometrySave.restart()
+      }
+      function recordPlacementGeometry(raw) {
+        var value
+        try { value = JSON.parse(String(raw || "")) } catch (error) { return }
+        if (String(value.title || "") !== title ||
+            !Number.isInteger(value.x) || !Number.isInteger(value.y) ||
+            !Number.isInteger(value.width) || !Number.isInteger(value.height))
+          return
+        placementObservedGeometry = value
+      }
+      function finishInitialPlacement(restored) {
+        placementStarted = false
+        var observed = restored ? null : placementObservedGeometry
+        if (!restored && !observed) {
+          placementRecoveryPending = true
+          return
+        }
+        resizeCards.setProperty(index, "placeOnMap", false)
+        if (observed) {
+          resizeCards.setProperty(index, "monitor", observed.monitor)
+          resizeCards.setProperty(index, "surfaceX", observed.x)
+          resizeCards.setProperty(index, "surfaceY", observed.y)
+          resizeCards.setProperty(index, "surfaceWidth", observed.width)
+          resizeCards.setProperty(index, "surfaceHeight", observed.height)
+          desiredWidth = observed.width
+          desiredHeight = observed.height
+          pendingWidth = observed.width
+          pendingHeight = observed.height
+          localResizePending = false
+          persistedRecovery = { monitor: observed.monitor,
+            x: observed.x, y: observed.y, width: observed.width,
+            height: observed.height }
+        }
+        placementObservedGeometry = null
+        placementRecoveryPending = false
+        if (closeAfterPlacement) {
+          closeAfterPlacement = false
+          closedAfterRecovery = true
+        }
+      }
+      function requestClose() {
+        if (placeOnMap || placementStarted || placementRecoveryPending) {
+          if (placementRecoveryAttempts >= 8 && !placementRecoveryPending &&
+              !placementStarted) {
+            closeAfterPlacement = false
+            closedAfterRecovery = true
+            return
+          }
+          closeAfterPlacement = true
+          return
+        }
+        closedAfterRecovery = true
+      }
+      function compositorClose() {
+        if (placeOnMap || placementStarted || placementRecoveryPending) {
+          if (placementRecoveryAttempts >= 8 && !placementRecoveryPending &&
+              !placementStarted) {
+            closeAfterPlacement = false
+            closedAfterRecovery = true
+            return
+          }
+          closeAfterPlacement = true
+          return
+        }
+        closedAfterRecovery = true
       }
       onSurfaceWidthChanged: syncDesiredWidth()
       onSurfaceHeightChanged: syncDesiredHeight()
@@ -302,6 +453,18 @@ ShellRoot {
       // An idle helper/compositor snapshot remains authoritative.
       resizeCards.setProperty(0, "surfaceWidth", 640)
       resizeCards.setProperty(0, "surfaceHeight", 720)
+      // Exhausted placement must release the card and retain actual geometry.
+      resizeCards.setProperty(1, "placeOnMap", true)
+      groupResize.placementStarted = true
+      groupResize.requestClose()
+      groupResize.recordPlacementGeometry("{malformed")
+      groupResize.finishInitialPlacement(false)
+      baseGeometryOk = baseGeometryOk && groupResize.placeOnMap &&
+        groupResize.placementRecoveryPending && groupResize.closeAfterPlacement &&
+        !closedAfterRecovery && persistedRecovery === null
+      groupResize.recordPlacementGeometry(JSON.stringify({ title: "Group",
+        monitor: "HDMI-A-1", x: 700, y: 350, width: 555, height: 695 }))
+      groupResize.finishInitialPlacement(false)
     }
   }
   Timer {
@@ -310,9 +473,29 @@ ShellRoot {
     onTriggered: {
       var externalSync = directResize.desiredWidth === 640 &&
         directResize.desiredHeight === 720 && directResize.pendingWidth === 640 &&
-        directResize.pendingHeight === 720 &&
-        groupResize.desiredWidth === 540 && groupResize.desiredHeight === 680
-      console.log(baseGeometryOk && externalSync
+        directResize.pendingHeight === 720 && !groupResize.placeOnMap &&
+        !groupResize.placementStarted && !groupResize.localResizePending &&
+        groupResize.monitor === "HDMI-A-1" && groupResize.surfaceX === 700 &&
+        groupResize.surfaceY === 350 && groupResize.desiredWidth === 555 &&
+        groupResize.desiredHeight === 695 && groupResize.pendingWidth === 555 &&
+        groupResize.pendingHeight === 695 && persistedRecovery !== null &&
+        persistedRecovery.monitor === "HDMI-A-1" && persistedRecovery.x === 700 &&
+        persistedRecovery.y === 350 && persistedRecovery.width === 555 &&
+        persistedRecovery.height === 695 && closedAfterRecovery &&
+        !groupResize.closeAfterPlacement
+      var recoveredClose = closedAfterRecovery
+      closedAfterRecovery = false
+      resizeCards.setProperty(1, "placeOnMap", true)
+      groupResize.placementRecoveryAttempts = 8
+      groupResize.requestClose()
+      var exhaustedExplicitClose = closedAfterRecovery
+      closedAfterRecovery = false
+      resizeCards.setProperty(0, "placeOnMap", true)
+      directResize.placementRecoveryAttempts = 8
+      directResize.compositorClose()
+      var exhaustedCompositorClose = closedAfterRecovery
+      console.log(baseGeometryOk && externalSync && recoveredClose &&
+        exhaustedExplicitClose && exhaustedCompositorClose
         ? "OMAQ_GEOMETRY_OK" : "OMAQ_GEOMETRY_BAD")
       Qt.quit()
     }

--- a/tests/float-script.sh
+++ b/tests/float-script.sh
@@ -33,8 +33,18 @@ if [ "$1" = "eval" ]; then
   [ "${OMAQ_FLOAT_LUA:-0}" = "1" ] && exit 0
   exit 1
 fi
+if [ "$1" = "dispatch" ] && [ -n "${OMAQ_FLOAT_BREAK_AFTER_DISPATCH:-}" ]; then
+  : >"$OMAQ_FLOAT_BREAK_AFTER_DISPATCH"
+fi
+if [ "$1" = "dispatch" ] && [ "${OMAQ_FLOAT_FAIL_DISPATCH:-0}" = "1" ]; then
+  exit 1
+fi
 if [ "$1" = "-j" ] && [ "${2:-}" = "clients" ]; then
-  if [ "${OMAQ_FLOAT_NO_CLIENTS:-0}" = "1" ]; then
+  if [ "${OMAQ_FLOAT_BAD_CLIENTS:-0}" = "1" ] ||
+     { [ -n "${OMAQ_FLOAT_BREAK_AFTER_DISPATCH:-}" ] &&
+       [ -e "$OMAQ_FLOAT_BREAK_AFTER_DISPATCH" ]; }; then
+    printf '%s\n' '{'
+  elif [ "${OMAQ_FLOAT_NO_CLIENTS:-0}" = "1" ]; then
     printf '%s\n' '[]'
   else
     printf '%s\n' '[{"title":"OmaQ chat — Alice · 0","address":"0xabc","floating":true,"monitor":1,"at":[40,80],"size":[420,420]},{"title":"OmaQ chat — Bob · 1","address":"0xdef","floating":true,"monitor":2,"at":[512,144],"size":[460,520]}]'
@@ -102,13 +112,21 @@ grep -q '^dispatch focuswindow address:0xabc$' "$OMAQ_FLOAT_TEST_LOG" || {
   echo "float-script: address focus missing" >&2
   exit 1
 }
-"$root/scripts/float-omaq.sh" place-title "OmaQ chat — Bob · 1" 512 144 460 520
-grep -q '^dispatch resizewindowpixel exact 460 520,address:0xdef$' \
+classic_placement=$("$root/scripts/float-omaq.sh" place-title \
+  "OmaQ chat — Bob · 1" 900 400 700 650)
+printf '%s' "$classic_placement" | jq -e '
+  .title == "OmaQ chat — Bob · 1" and .monitor == "HDMI-A-1" and
+  .x == 512 and .y == 144 and .width == 460 and .height == 520 and
+  has("address") == false' >/dev/null || {
+  echo "float-script: classic placement observation missing" >&2
+  exit 1
+}
+grep -q '^dispatch resizewindowpixel exact 700 650,address:0xdef$' \
   "$OMAQ_FLOAT_TEST_LOG" || {
   echo "float-script: per-chat resize missing" >&2
   exit 1
 }
-grep -q '^dispatch movewindowpixel exact 512 144,address:0xdef$' \
+grep -q '^dispatch movewindowpixel exact 900 400,address:0xdef$' \
   "$OMAQ_FLOAT_TEST_LOG" || {
   echo "float-script: per-chat placement missing" >&2
   exit 1
@@ -117,7 +135,41 @@ if grep -E 'windowpixel .*address:0xabc' "$OMAQ_FLOAT_TEST_LOG"; then
   echo "float-script: placing one chat changed another chat" >&2
   exit 1
 fi
-geometry=$($root/scripts/float-omaq.sh list-geometry)
+export OMAQ_FLOAT_FAIL_DISPATCH=1
+set +e
+failed_placement=$("$root/scripts/float-omaq.sh" place-title \
+  "OmaQ chat — Bob · 1" 900 400 700 650)
+failed_status=$?
+set -e
+unset OMAQ_FLOAT_FAIL_DISPATCH
+if [ "$failed_status" -ne 4 ] || ! printf '%s' "$failed_placement" | jq -e '
+  .x == 512 and .y == 144 and .width == 460 and .height == 520' >/dev/null; then
+  echo "float-script: failed dispatch did not return actual geometry" >&2
+  exit 1
+fi
+export OMAQ_FLOAT_BAD_CLIENTS=1
+set +e
+malformed_placement=$("$root/scripts/float-omaq.sh" place-title \
+  "OmaQ chat — Bob · 1" 900 400 700 650 2>/dev/null)
+malformed_status=$?
+set -e
+unset OMAQ_FLOAT_BAD_CLIENTS
+if [ "$malformed_status" -ne 3 ] || [ -n "$malformed_placement" ]; then
+  echo "float-script: malformed compositor snapshot did not fail closed" >&2
+  exit 1
+fi
+export OMAQ_FLOAT_BREAK_AFTER_DISPATCH="$tmp/break-after-dispatch"
+set +e
+missing_final=$("$root/scripts/float-omaq.sh" place-title \
+  "OmaQ chat — Bob · 1" 900 400 700 650 2>/dev/null)
+missing_final_status=$?
+set -e
+unset OMAQ_FLOAT_BREAK_AFTER_DISPATCH
+if [ "$missing_final_status" -ne 3 ] || [ -n "$missing_final" ]; then
+  echo "float-script: missing final observation reported placement success" >&2
+  exit 1
+fi
+geometry=$("$root/scripts/float-omaq.sh" list-geometry)
 printf '%s' "$geometry" | jq -e '
   length == 2 and .[0].title == "OmaQ chat — Alice · 0" and
   .[0].x == 40 and .[0].width == 420 and .[0].monitor == "DP-1" and
@@ -247,6 +299,29 @@ grep -q 'hl.dsp.window.bring_to_top({ window = "address:0xabc" })' \
   echo "float-script: Lua focus missing" >&2
   exit 1
 }
+lua_placement=$("$root/scripts/float-omaq.sh" place-title \
+  "OmaQ chat — Bob · 1" 900 400 700 650)
+printf '%s' "$lua_placement" | jq -e '
+  .title == "OmaQ chat — Bob · 1" and .monitor == "HDMI-A-1" and
+  .x == 512 and .y == 144 and .width == 460 and .height == 520 and
+  has("address") == false' >/dev/null || {
+  echo "float-script: Lua placement observation missing" >&2
+  exit 1
+}
+grep -Fq 'hl.dsp.window.resize({ x = 700, y = 650, relative = false, window = "address:0xdef" })' \
+  "$OMAQ_FLOAT_TEST_LOG" || {
+  echo "float-script: Lua per-chat resize missing" >&2
+  exit 1
+}
+grep -Fq 'hl.dsp.window.move({ x = 900, y = 400, relative = false, window = "address:0xdef" })' \
+  "$OMAQ_FLOAT_TEST_LOG" || {
+  echo "float-script: Lua per-chat placement missing" >&2
+  exit 1
+}
+if grep -Eq 'resizewindowpixel|movewindowpixel' "$OMAQ_FLOAT_TEST_LOG"; then
+  echo "float-script: legacy placement used despite Lua support" >&2
+  exit 1
+fi
 if grep -Eq 'window\.float|setfloating|fullscreenstate' "$OMAQ_FLOAT_TEST_LOG"; then
   echo "float-script: focusing an existing chat changed its tiling state" >&2
   exit 1


### PR DESCRIPTION
## Summary

- use Hyprland's Lua resize/move dispatchers when Lua mode is available, while retaining the classic fallback
- persist the exact compositor-observed geometry and release failed placement without leaving manual resizing blocked
- bound placement and recovery processes, retries, and deferred close handling
- add regression coverage for successful, partial, malformed, exhausted, and close-race paths

## Validation

- `make verify-0`
- `qmllint ChatSurface.qml pages/ChatPage.qml Service.qml`
- `shellcheck scripts/float-omaq.sh tests/float-script.sh tests/chat-surface-geometry.sh`
- `omarchy plugin validate .`
- `git diff --check`
- independent code review: 0 findings

Native visible Wayland behavior was not automated or claimed by these checks.
