### PR TITLE
Restore concise README layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,52 +8,32 @@
 
 OmaQ creates your identity locally. Connect with another person by sharing a one-time private invitation as a link or QR code.
 
-## Documentation
-
-Use the task guides for setup, daily use, security, recovery, and removal. Each visual guide links its screenshots to the full-size original.
-
-<table>
-<tr>
-<td width="33%" valign="top">
-<a href="docs/USER-GUIDE.md"><img src="docs/images/guide/01-panel-home.png" alt="OmaQ panel home" width="260"></a><br>
-<strong><a href="docs/USER-GUIDE.md">Illustrated user guide</a></strong><br>
-Create invitations, chat, exchange files, manage groups, and protect your identity.
-</td>
-<td width="33%" valign="top">
-<a href="docs/SECURITY.md"><img src="docs/images/omaq-message-flow.png" alt="OmaQ encrypted message flow" width="260"></a><br>
-<strong><a href="docs/SECURITY.md">Security and privacy</a></strong><br>
-Understand transport encryption, relay privacy, local storage, and passphrase limits.
-</td>
-<td width="33%" valign="top">
-<a href="docs/INSTALLATION.md"><img src="docs/images/guide/15-direct-chat-overview.png" alt="OmaQ DirectChat" width="260"></a><br>
-<strong><a href="docs/INSTALLATION.md">Install, update, or remove OmaQ</a></strong><br>
-Follow the supported lifecycle commands, status checks, rollback, and retained-data guidance.
-</td>
-</tr>
-</table>
-
-Technical documentation:
-
-- [Documentation index](docs/README.md)
-- [Current product status](docs/CURRENT.md)
-- [Architecture and verification plan](docs/PLAN.md)
-- [Third-party components](THIRD_PARTY.md)
-
 ## Security
 
 Tox encrypts transport end to end, and direct text messages add the Signal Double Ratchet. OmaQ disables direct UDP discovery and hole punching, so contacts do not receive each other's IP addresses.
 
-OmaQ runs no servers and has no operator access to your identity, contacts, or messages. Public Tox bootstrap and relay nodes can forward encrypted packets but cannot read message contents. Read the [security and privacy model](docs/SECURITY.md) for storage boundaries and metadata limits.
+OmaQ runs no servers and has no operator access to your identity, contacts, or messages. Public Tox bootstrap and relay nodes can forward encrypted packets but cannot read message contents. Local filesystem permissions protect Ratchet state, avatars, receipts, preferences, and chat history that are not covered by the optional `tox.save` passphrase.
 
 ## How OmaQ works
 
-[![How OmaQ messages travel](docs/images/omaq-message-flow.png)](docs/SECURITY.md)
+![How OmaQ messages travel](docs/images/omaq-message-flow.png)
 
 Toxcore transports encrypted packets between peers. Direct messages receive an additional Signal Double Ratchet layer, while identity and history remain in local storage.
 
 ## Install
 
-Arch User Repository (AUR) packaging remains paused. Follow the [source installation guide](docs/INSTALLATION.md#install-omaq) to add the plugin, build its Signal-enabled helper, and verify both components.
+Arch User Repository (AUR) packaging remains paused. Install the dependencies, add the plugin, and build its local Signal-enabled helper:
+
+```bash
+omarchy pkg add \
+  toxcore libsignal-protocol-c libpulse libpng libjpeg-turbo libwebp \
+  ttf-material-symbols-variable qrencode &&
+omarchy plugin add \
+  https://github.com/HANCORE-linux/OmaQ.git --enable &&
+make -C ~/.config/omarchy/plugins/hancore.omaq helper
+```
+
+The repository intentionally omits the generated `helper/omaq` binary, and direct messaging is refused when the Signal Ratchet helper is unavailable.
 
 ## Update
 
@@ -65,14 +45,18 @@ omarchy restart shell &&
 ~/.config/omarchy/plugins/hancore.omaq/scripts/update-helper.sh --activate
 ```
 
-The immediate shell restart clears plugin hot-reload state before helper activation; the [update guide](docs/INSTALLATION.md#update-omaq) covers status, pending groups, and rollback.
+The immediate shell restart clears plugin hot-reload state before helper activation; the update documentation covers status, pending groups, and rollback.
 
 ## Uninstall
 
-Run the verified wrapper; when the helper is running, removal requires confirmed durable group-free state and lists every retained path:
+Run the verified wrapper:
 
 ```bash
 ~/.config/omarchy/plugins/hancore.omaq/scripts/uninstall-omaq.sh
 ```
 
-Keep retained data if you may reinstall OmaQ or still need the identity or history. The [removal guide](docs/INSTALLATION.md#remove-omaq) lists retained paths, irreversible deletion commands, and optional package cleanup.
+Keep retained data if you may reinstall OmaQ or still need the identity or history. Private data, local state, received files, backups, and dependency packages remain available for manual inspection or removal.
+
+## Documentation
+
+[Documentation index](docs/README.md) · [Illustrated user guide](docs/USER-GUIDE.md) · [Installation lifecycle](docs/INSTALLATION.md) · [Security and privacy](docs/SECURITY.md) · [Current status](docs/CURRENT.md) · [Architecture plan](docs/PLAN.md) · [Third-party components](THIRD_PARTY.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,36 +1,14 @@
-# Documentation
+# OmaQ documentation
 
-Use this index to install OmaQ, learn the interface, understand its security boundaries, or review the technical contract.
+## User documentation
 
-## Use OmaQ
+- [Illustrated user guide](USER-GUIDE.md): invitations, chats, files, calls, groups, identity protection, and recovery
+- [Installation lifecycle](INSTALLATION.md): installation, safe updates, helper status, rollback, removal, and retained data
+- [Security and privacy](SECURITY.md): encryption, relay privacy, local storage, identity protection, and safety codes
 
-<table>
-<tr>
-<td width="33%" valign="top">
-<a href="USER-GUIDE.md"><img src="images/guide/01-panel-home.png" alt="OmaQ panel home" width="260"></a><br>
-<strong><a href="USER-GUIDE.md">Illustrated user guide</a></strong><br>
-Follow invitations, DirectChat, GroupChat, files, calls, identity protection, and recovery with full-size screenshots.
-</td>
-<td width="33%" valign="top">
-<a href="SECURITY.md"><img src="images/omaq-message-flow.png" alt="OmaQ encrypted message flow" width="260"></a><br>
-<strong><a href="SECURITY.md">Security and privacy</a></strong><br>
-Review encryption layers, relay privacy, local storage boundaries, identity protection, and safety-code verification.
-</td>
-<td width="33%" valign="top">
-<a href="INSTALLATION.md"><img src="images/guide/15-direct-chat-overview.png" alt="OmaQ DirectChat" width="260"></a><br>
-<strong><a href="INSTALLATION.md">Install, update, or remove OmaQ</a></strong><br>
-Run supported lifecycle commands, check the helper, recover a degraded update, and inspect retained data.
-</td>
-</tr>
-</table>
+## Project references
 
-## Review implementation status
-
-These documents describe the current build and its technical constraints:
-
-| Document | Purpose |
-|---|---|
-| [Current product status](CURRENT.md) | Deployed protocol, completed features, validation evidence, and known limitations |
-| [Architecture and verification plan](PLAN.md) | Helper authority, protocol boundaries, phases, and verification gates |
-| [Stage notes](stages/README.md) | Completed implementation stages and focused decisions |
-| [Third-party components](../THIRD_PARTY.md) | toxcore, Signal protocol, OpenSSL, media libraries, and asset attribution |
+- [Current status](CURRENT.md): deployed protocol, completed features, validation, and known limitations
+- [Architecture plan](PLAN.md): helper authority, protocol boundaries, implementation phases, and verification gates
+- [Stage notes](stages/README.md): completed implementation stages and focused decisions
+- [Third-party components](../THIRD_PARTY.md): libraries and asset attribution


### PR DESCRIPTION
## Summary

- restore the complete source installation command in the root README
- keep the update and uninstall commands directly in the README
- move documentation references to one compact link row at the bottom
- simplify the documentation index to short task-based lists

## Validation

- `make arch`
- `git diff --check`
- local README structure and link checks
- independent review with no findings