### PR TITLE
Polish README and panel icons

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -3131,6 +3131,7 @@ BarWidget {
               materialIcon: "shield"
               label: "Safety code"
               selected: root.moreOpen && root.moreSection === "chat"
+              fillSelected: false
               onClicked: root.openRailAdvanced("chat")
             }
             RailIcon {
@@ -3180,6 +3181,7 @@ BarWidget {
                 materialIcon: "badge"
                 label: "Identity"
                 selected: root.moreOpen && root.moreSection === "identity"
+                fillSelected: false
                 onClicked: root.openRailAdvanced("identity")
               }
             }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# OmaQ
-
-<p align="center">
-  <img src="assets/OmaQ_Final.png" alt="" width="420">
-</p>
+<h1 align="center">
+  <img src="assets/OmaQ_Final.png" alt="OmaQ" width="420">
+</h1>
 
 <p align="center">
   OmaQ is invite-only chat for the Omarchy bar: no account, phone number, or public user search.<br>

--- a/docs/CURRENT.md
+++ b/docs/CURRENT.md
@@ -7,7 +7,7 @@ This page is the current product and release snapshot. Completed phase and follo
 - **Project:** OmaQ, plugin id `hancore.omaq`
 - **Branch:** `main`
 - **Manifest version:** `0.8.1-beta.1`, Protocol 14
-- **Live plugins:** both installations are clean Git-managed checkouts at `580c69cf7583ccca4461bd265334edc0a692b65d`
+- **Live plugins:** the primary installation is at `5a86d7ea49449934a499213e5d876f41f56d9325` with one ignored test-harness bytecode cache pending atomic cleanup; the second installation remains a clean Git-managed checkout at `580c69cf7583ccca4461bd265334edc0a692b65d`
 - **Live helper:** Protocol 14, SHA-256 `ee43637be9ac9880bb465408a87c8ace94015c217a1df25dc79ce088308a1fba`
 - **AUR:** paused; no registration or upload
 - **Documentation:** the task-based [documentation index](README.md) links the illustrated guide, security model, installation lifecycle, and historical notes
@@ -59,13 +59,13 @@ Uninstall regressions cover current and legacy rule names, interrupted temporary
 
 The default UHOH notification is now the project-generated `sounds/uhoh.wav` at SHA-256 `8a27ca4badca8aa1074e2e41e2ad8c2c591e5ac3628fb680252d2bd0308c9744`. It is lossless 48 kHz signed 16-bit stereo PCM, begins and ends at zero, has 24% peak amplitude, and has a maximum adjacent-sample delta of 679. The manifest records GPL-3.0-only for the distributed payload; README and `THIRD_PARTY.md` distinguish OmaQ's GPL-3.0-or-later helper source from the GPL-3.0-only linked helper binary imposed by `libsignal-protocol-c` 2.3.3.
 
-No current test claims visible native Wayland or multi-monitor acceptance. The first authorized primary-machine update attempt failed during its external remote preflight because the private origin had no noninteractive credential; it did not stop the shell or modify the live checkout. After authenticated acquisition was added, the shell-off exchange installed `7fde5c2c4b0e74c1717e8ac1baf2809694b2b393`, but the controller treated asynchronous shell startup as an immediate failure and entered rollback. Stopping that loading instance reproduced the known Quickshell `QQuickLoader`/`__dynamic_cast` crash, and a replacement supervisor appeared faster than the rollback stop handled it. The tree therefore remained on the new commit. The shell subsequently stabilized with exactly one supervisor, Quickshell process, and watcher; plugin IPC, the clean canonical checkout, Protocol 14 helper PID and hash, the previous tree, and a no-op update without any process or staging change all passed acceptance. This follow-up waits for complete shell readiness and terminates every bound supervisor that appears during a stop. The second machine remains on `580c69cf7583ccca4461bd265334edc0a692b65d`; no private identity, Ratchet, group registry, or history data was synchronized.
+No current test claims visible native Wayland or multi-monitor acceptance. The first authorized primary-machine update attempt failed during its external remote preflight because the private origin had no noninteractive credential; it did not stop the shell or modify the live checkout. After authenticated acquisition was added, the shell-off exchange installed `7fde5c2c4b0e74c1717e8ac1baf2809694b2b393`, but the controller treated asynchronous shell startup as an immediate failure and entered rollback. Stopping that loading instance reproduced the known Quickshell `QQuickLoader`/`__dynamic_cast` crash, and a replacement supervisor appeared faster than the rollback stop handled it. The tree therefore remained on the new commit. The shell-readiness follow-up then installed `5a86d7ea49449934a499213e5d876f41f56d9325` with a clean restart, no new coredump, a bound previous tree, Protocol 14 helper continuity, complete consumer acceptance, and a same-commit no-op without process or staging changes. A later acceptance harness mistakenly imported the live controller and created an ignored Python bytecode cache, causing one hot reload without a crash; the next full tree exchange will discard that cache without an active-tree deletion. The second machine remains on `580c69cf7583ccca4461bd265334edc0a692b65d`; no private identity, Ratchet, group registry, or history data was synchronized.
 
 ## Next order
 
-1. Merge and audit the shell-readiness follow-up.
-2. Update the primary machine to that exact reviewed commit and confirm a clean restart plus no-op.
+1. Merge and audit the README and panel-icon polish.
+2. Update the primary machine to that exact reviewed commit, discarding the generated cache through the full tree exchange.
 3. Update the second machine only after separate approval and primary-machine acceptance.
 4. Prepare the Quickshell upstream crash report.
-5. Investigate the Panel QML toolchain failure.
+5. Finalize the beta release notes.
 6. Decide separately whether a governed Git-history migration is warranted for the retired sound blob.

--- a/tests/panel-request-focus.sh
+++ b/tests/panel-request-focus.sh
@@ -57,6 +57,15 @@ for forbidden in ('placeholderText: "Search this chat"', 'text: "Search"',
         raise SystemExit(f"panel-request-focus: panel message search remains: {forbidden}")
 if 'label: "Safety code"' not in panel or 'text: "Show safety code"' not in panel:
     raise SystemExit("panel-request-focus: safety-code path was removed with message search")
+if '"FILL": railIcon.selected && railIcon.fillSelected ? 1 : 0' not in panel:
+    raise SystemExit("panel-request-focus: rail icon fill binding changed")
+for icon, label in (("shield", "Safety code"), ("badge", "Identity")):
+    start = panel.index(f'materialIcon: "{icon}"')
+    end = panel.index("onClicked:", start)
+    if "fillSelected: false" not in panel[start:end]:
+        raise SystemExit(
+            f"panel-request-focus: {label} rail icon changes glyph fill when selected"
+        )
 if 'text: "YOU · " + root.connectionLabel().toUpperCase()' not in self_block:
     raise SystemExit("panel-request-focus: normal self status is missing")
 for forbidden in ("omaq.selfAvatar", "omaq.selfNickname", '"YOU · "'):

--- a/tests/qml_plaintext_test.py
+++ b/tests/qml_plaintext_test.py
@@ -19,7 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 QML_POLICY_SHA256 = {
     "CallTone.qml": "12d873ec1b774ed038fb526b0b2b7fd2a1a71e97d9987aa27fef06f6f4d93ddc",
     "ChatSurface.qml": "e40d764c67ba056748efc681af0749893e826f16fc2bbe3fa4e7026b3cd11c97",
-    "Panel.qml": "dfdae066a00c3acc1931c673b26ce67bc31a56ca98a5fb880813f08acd623401",
+    "Panel.qml": "f282727e462f98fa36f426fe946de570a2101ab4f8b5407c37c3cf1111edb32a",
     "PlacementController.qml": "82f72fcee9a6aceeb6d1015095fea4961eb2cddbdc11943ef410e160060df76a",
     "SafeText.qml": "a8bfa2ea5e13cbd50bf7e9c70995bea06ceeaca9c9d61e63b243ce18a830e354",
     "Service.qml": "8d89679c5e6a1ead4c1c7d1479e804d6ee0bc8cddf982e4523629122d48d94dc",
@@ -146,7 +146,7 @@ REVIEWED_COMPUTED_IDS = set().union(*COMPUTED_WRITE_ALLOWLIST.values())
 COMPUTED_WRITE_SOURCE_SHA256 = {
     "CallTone.qml": "8d9a0af95e58b888dfd09e37c198684843aa10d306f815abc868b88c61496c86",
     "ChatSurface.qml": "536820193eb50bd63cb5777b65eb6f647086f407fe1a1dce6db432806dc7c481",
-    "Panel.qml": "66dc7079d62294591101cd24da2e4ede855bc12b58d6d7da803688da226254d8",
+    "Panel.qml": "8c7739e4396b350f6df272fa9a53e49fd40840f6bd9955c9e3ca6e71e12aa153",
     "Service.qml": "90015a29d7e7cdc9c52ad81bf1b748ebc042cf33805a1f1f90e59f5ea5f51b2d",
     "pages/ChatPage.qml": "ba714366e6928a4fed978235118d4bc95065cf41b48e75b4d1b57dce6d80caf3",
 }


### PR DESCRIPTION
## Summary

- use the centered OmaQ logo as the only visible README heading while retaining semantic H1 and alternative text
- keep the Safety code `shield` and Identity `badge` rail icons outlined when selected
- preserve the shared active accent, font weight, hinting, and Qt text rendering used by the other panel icons
- add focused fill-policy coverage and update the reviewed PlainText snapshots
- record the completed primary-machine updater acceptance and pending atomic cleanup of a test-harness bytecode cache

## Testing

- isolated post-commit archive SHA-256: `07f6425eee8f622554b7b4cc0dd89d41768dd6da88baf0813a08c68539efb224`
- `make verify-4`
- 38 source-update tests
- panel source and Wayland runtime fixture
- QML PlainText policy
- `qmlformat Panel.qml`
- `qmllint Panel.qml`
- `git diff --check`
- independent Quickshell/QML review; accessibility finding resolved
- rejected redesign commit remains unreachable

## Deployment

These changes are not live. Machine 1 remains on `5a86d7ea49449934a499213e5d876f41f56d9325`; Machine 2 remains on `580c69cf7583ccca4461bd265334edc0a692b65d`.
