### PR TITLE
Support semantic Omarchy theme colors

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1752,12 +1752,28 @@ BarWidget {
 
   function parseSystemColors(raw) {
     var found = ["", "", "", "", "", "", "", ""]
+    var semanticIndex = {
+      background: 0,
+      red: 1,
+      green: 2,
+      yellow: 3,
+      blue: 4,
+      magenta: 5,
+      cyan: 6,
+      foreground: 7
+    }
     var lines = String(raw || "").split("\n")
     var i
     for (i = 0; i < lines.length; i++) {
-      var match = lines[i].match(/^\s*color([0-7])\s*=\s*["']?(#[0-9A-Fa-f]{6})/)
-      if (match)
-        found[Number(match[1])] = match[2]
+      var semanticMatch = lines[i].match(
+        /^\s*(background|red|green|yellow|blue|magenta|cyan|foreground)\s*=\s*["']?(#[0-9A-Fa-f]{6})/)
+      if (semanticMatch)
+        found[semanticIndex[semanticMatch[1]]] = semanticMatch[2]
+    }
+    for (i = 0; i < lines.length; i++) {
+      var ansiMatch = lines[i].match(/^\s*color([0-7])\s*=\s*["']?(#[0-9A-Fa-f]{6})/)
+      if (ansiMatch)
+        found[Number(ansiMatch[1])] = ansiMatch[2]
     }
     var n
     for (n = 0; n < 8; n++) {

--- a/docs/CURRENT.md
+++ b/docs/CURRENT.md
@@ -1,4 +1,4 @@
-# Current status: 2026-09-02
+# Current status: 2026-09-03
 
 This page is the current product and release snapshot. Completed phase and follow-up history lives in the [stage notes](stages/README.md).
 
@@ -7,7 +7,7 @@ This page is the current product and release snapshot. Completed phase and follo
 - **Project:** OmaQ, plugin id `hancore.omaq`
 - **Branch:** `main`
 - **Manifest version:** `0.8.1-beta.1`, Protocol 14
-- **Live plugins:** the primary installation is at `5a86d7ea49449934a499213e5d876f41f56d9325` with one ignored test-harness bytecode cache pending atomic cleanup; the second installation remains a clean Git-managed checkout at `580c69cf7583ccca4461bd265334edc0a692b65d`
+- **Live plugins:** the primary installation is a clean Git-managed checkout at `07f43f99f44ccfd80a6c31cbbe9d40234855e6be`; the second installation remains a clean Git-managed checkout at `580c69cf7583ccca4461bd265334edc0a692b65d`
 - **Live helper:** Protocol 14, SHA-256 `ee43637be9ac9880bb465408a87c8ace94015c217a1df25dc79ce088308a1fba`
 - **AUR:** paused; no registration or upload
 - **Documentation:** the task-based [documentation index](README.md) links the illustrated guide, security model, installation lifecycle, and historical notes
@@ -51,7 +51,7 @@ This page is the current product and release snapshot. Completed phase and follo
 
 ## Latest validation
 
-The release-audit follow-up passes the full `make test` aggregate, `make verify-4`, `make helper`, `make arch`, phase 2, phase 8, Omarchy plugin validation, ShellCheck on every changed shell file, Qt parsing for all eight QML files, `qmllint` for ChatSurface, ChatPage, and Service, syntax checks, and `git diff --check`. The known `qmllint Panel.qml` limitation remains exit 255 without diagnostics.
+The release-audit follow-up passes the full `make test` aggregate, `make verify-4`, `make helper`, `make arch`, phase 2, phase 8, Omarchy plugin validation, ShellCheck on every changed shell file, Qt parsing for all eight QML files, `qmllint` for ChatSurface, ChatPage, Service, and Panel, syntax checks, and `git diff --check`. Panel runtime coverage verifies both semantic Omarchy theme keys and legacy `color0`–`color7` palettes, including deterministic legacy precedence in a mixed file.
 
 Repeated phase 2 runs measured 13.2 to 15.2 MB helper RSS against the documented absolute 51,200 kB limit. Repeated phase 6 runs passed file, timestamp, call, and public-network diagnostics with 30 to 32 MB call RSS. Attachment checks wait for sender and receiver events plus both local history entries, then compare each event only with its matching local history timestamp.
 
@@ -59,12 +59,12 @@ Uninstall regressions cover current and legacy rule names, interrupted temporary
 
 The default UHOH notification is now the project-generated `sounds/uhoh.wav` at SHA-256 `8a27ca4badca8aa1074e2e41e2ad8c2c591e5ac3628fb680252d2bd0308c9744`. It is lossless 48 kHz signed 16-bit stereo PCM, begins and ends at zero, has 24% peak amplitude, and has a maximum adjacent-sample delta of 679. The manifest records GPL-3.0-only for the distributed payload; README and `THIRD_PARTY.md` distinguish OmaQ's GPL-3.0-or-later helper source from the GPL-3.0-only linked helper binary imposed by `libsignal-protocol-c` 2.3.3.
 
-No current test claims visible native Wayland or multi-monitor acceptance. The first authorized primary-machine update attempt failed during its external remote preflight because the private origin had no noninteractive credential; it did not stop the shell or modify the live checkout. After authenticated acquisition was added, the shell-off exchange installed `7fde5c2c4b0e74c1717e8ac1baf2809694b2b393`, but the controller treated asynchronous shell startup as an immediate failure and entered rollback. Stopping that loading instance reproduced the known Quickshell `QQuickLoader`/`__dynamic_cast` crash, and a replacement supervisor appeared faster than the rollback stop handled it. The tree therefore remained on the new commit. The shell-readiness follow-up then installed `5a86d7ea49449934a499213e5d876f41f56d9325` with a clean restart, no new coredump, a bound previous tree, Protocol 14 helper continuity, complete consumer acceptance, and a same-commit no-op without process or staging changes. A later acceptance harness mistakenly imported the live controller and created an ignored Python bytecode cache, causing one hot reload without a crash; the next full tree exchange will discard that cache without an active-tree deletion. The second machine remains on `580c69cf7583ccca4461bd265334edc0a692b65d`; no private identity, Ratchet, group registry, or history data was synchronized.
+No current test claims visible native Wayland or multi-monitor acceptance. The first authorized primary-machine update attempt failed during its external remote preflight because the private origin had no noninteractive credential; it did not stop the shell or modify the live checkout. After authenticated acquisition was added, the shell-off exchange installed `7fde5c2c4b0e74c1717e8ac1baf2809694b2b393`, but the controller treated asynchronous shell startup as an immediate failure and entered rollback. Stopping that loading instance reproduced the known Quickshell `QQuickLoader`/`__dynamic_cast` crash, and a replacement supervisor appeared faster than the rollback stop handled it. The tree therefore remained on the new commit. The shell-readiness follow-up then installed `5a86d7ea49449934a499213e5d876f41f56d9325` with a clean restart, no new coredump, a bound previous tree, Protocol 14 helper continuity, complete consumer acceptance, and a same-commit no-op without process or staging changes. A later acceptance harness mistakenly imported the live controller and created an ignored Python bytecode cache, causing one hot reload without a crash. The README and panel-icon polish subsequently installed `07f43f99f44ccfd80a6c31cbbe9d40234855e6be` with another clean restart and removed that cache through the full atomic tree exchange; checkout, previous-tree, plugin-consumer, and unchanged Protocol 14 helper bindings passed without a new coredump. The second machine remains on `580c69cf7583ccca4461bd265334edc0a692b65d`; no private identity, Ratchet, group registry, or history data was synchronized.
 
 ## Next order
 
-1. Merge and audit the README and panel-icon polish.
-2. Update the primary machine to that exact reviewed commit, discarding the generated cache through the full tree exchange.
+1. Merge and audit the system-theme compatibility fix.
+2. Update the primary machine to that exact reviewed commit and complete visible theme-switch plus same-commit no-op acceptance.
 3. Update the second machine only after separate approval and primary-machine acceptance.
 4. Prepare the Quickshell upstream crash report.
 5. Finalize the beta release notes.

--- a/tests/panel-request-focus.sh
+++ b/tests/panel-request-focus.sh
@@ -258,6 +258,24 @@ ShellRoot {
         panel.testService.selfNickname = "HANCORE"
         panel.testService.connectionState = "online"
         panel.testService.pending = false
+        var semanticPalette = ["#010203", "#111213", "#212223", "#313233",
+                               "#414243", "#515253", "#616263", "#717273"]
+        panel.parseSystemColors([
+          'background = "#010203"',
+          'red = "#111213"',
+          'green = "#212223"',
+          'yellow = "#313233"',
+          'blue = "#414243"',
+          'magenta = "#515253"',
+          'cyan = "#616263"',
+          'foreground = "#717273"'
+        ].join("\n"))
+        for (var colorIndex = 0; colorIndex < semanticPalette.length; colorIndex++)
+          testRoot.check(panel.systemColors[colorIndex] === semanticPalette[colorIndex],
+            "semantic system color " + colorIndex + " was not parsed")
+        panel.parseSystemColors('yellow = "#313233"\ncolor3 = "#a1a2a3"')
+        testRoot.check(panel.systemColors[3] === "#a1a2a3",
+          "legacy ANSI system color did not override its semantic equivalent")
       } else if (testRoot.step === 1) {
         testRoot.check(panel.testSelfAvatar.visible, "self avatar hidden without request")
         testRoot.check(panel.testSelfContent.visible, "self content hidden without request")

--- a/tests/qml_plaintext_test.py
+++ b/tests/qml_plaintext_test.py
@@ -19,7 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 QML_POLICY_SHA256 = {
     "CallTone.qml": "12d873ec1b774ed038fb526b0b2b7fd2a1a71e97d9987aa27fef06f6f4d93ddc",
     "ChatSurface.qml": "e40d764c67ba056748efc681af0749893e826f16fc2bbe3fa4e7026b3cd11c97",
-    "Panel.qml": "f282727e462f98fa36f426fe946de570a2101ab4f8b5407c37c3cf1111edb32a",
+    "Panel.qml": "6445b219d6d77b090359d18593df65ac71c3cbdf0d244c6a1727dbd0ec9ca299",
     "PlacementController.qml": "82f72fcee9a6aceeb6d1015095fea4961eb2cddbdc11943ef410e160060df76a",
     "SafeText.qml": "a8bfa2ea5e13cbd50bf7e9c70995bea06ceeaca9c9d61e63b243ce18a830e354",
     "Service.qml": "8d89679c5e6a1ead4c1c7d1479e804d6ee0bc8cddf982e4523629122d48d94dc",
@@ -146,7 +146,7 @@ REVIEWED_COMPUTED_IDS = set().union(*COMPUTED_WRITE_ALLOWLIST.values())
 COMPUTED_WRITE_SOURCE_SHA256 = {
     "CallTone.qml": "8d9a0af95e58b888dfd09e37c198684843aa10d306f815abc868b88c61496c86",
     "ChatSurface.qml": "536820193eb50bd63cb5777b65eb6f647086f407fe1a1dce6db432806dc7c481",
-    "Panel.qml": "8c7739e4396b350f6df272fa9a53e49fd40840f6bd9955c9e3ca6e71e12aa153",
+    "Panel.qml": "394b5bcc6f09ddfe997135fb701aefa7d961bdaa72fd009c319f5131208863a0",
     "Service.qml": "90015a29d7e7cdc9c52ad81bf1b748ebc042cf33805a1f1f90e59f5ea5f51b2d",
     "pages/ChatPage.qml": "ba714366e6928a4fed978235118d4bc95065cf41b48e75b4d1b57dce6d80caf3",
 }


### PR DESCRIPTION
## Summary

- parse modern semantic Omarchy theme keys as well as legacy `color0`–`color7` entries
- preserve deterministic legacy precedence for mixed files that provide both formats
- restore system palette previews and theme-derived panel hover/active colors without changing their bindings
- add Wayland runtime coverage for semantic mapping and mixed-format precedence
- update the current deployment snapshot after the clean primary-machine UI-polish exchange

## Cause

Current stock Omarchy themes such as Tokyo Night expose `background`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, and `foreground`. OmaQ previously recognized only `color0`–`color7`, so these themes fell back to neutral gray values in panel elements backed by `systemColors`.

## Testing

- isolated post-commit archive SHA-256: `17dae6b55323330428c1bf58cacbc0195ec918ab9ddb6fad6f1a3fd66f106487`
- `make verify-4`
- 38 source-update tests
- panel source and Wayland runtime fixture
- QML PlainText policy
- `qmlformat Panel.qml`
- `qmllint Panel.qml`
- `git diff --check`
- independent Quickshell/QML review: no findings
- rejected redesign commit remains unreachable

## Deployment

This fix is not live. Machine 1 remains on `07f43f99f44ccfd80a6c31cbbe9d40234855e6be`; Machine 2 remains on `580c69cf7583ccca4461bd265334edc0a692b65d`.
