### PR TITLE
Trim source installation boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ OmaQ runs no servers and has no operator access to your identity, contacts, or m
 
 ```bash
 mkdir -m 700 -- "$HOME/.omaq-source-install" &&
-/usr/bin/git clone --no-hardlinks --branch main --single-branch -- \
+git clone --no-hardlinks --branch main --single-branch -- \
   https://github.com/HANCORE-linux/OmaQ.git "$HOME/.omaq-source-install" &&
 "$HOME/.omaq-source-install/install.sh" --section right --yes
 ```
 
-`install.sh` installs the required packages, builds the omitted Signal-enabled `helper/omaq` outside the monitored plugin directory, moves the complete checkout to `~/.config/omarchy/plugins/hancore.omaq`, and places OmaQ in the right bar section. Change `--section right` to `left` or `center` if preferred. Shibumi V2 follows the same layout without a separate OmaQ installation path. Direct messaging remains unavailable when the helper is missing. See the [installation lifecycle](docs/INSTALLATION.md) for the bounded exact-commit bootstrap, verification, and recovery.
+This installs OmaQ and its dependencies in the right bar section. Use `left` or `center` if preferred.
 
 ## Update
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -15,7 +15,7 @@ Clone OmaQ and run its installer:
 
 ```bash
 mkdir -m 700 -- "$HOME/.omaq-source-install" &&
-/usr/bin/git clone --no-hardlinks --branch main --single-branch -- \
+git clone --no-hardlinks --branch main --single-branch -- \
   https://github.com/HANCORE-linux/OmaQ.git "$HOME/.omaq-source-install" &&
 "$HOME/.omaq-source-install/install.sh" --section right --yes
 ```
@@ -24,7 +24,7 @@ The private checkout is a direct child of your home directory, outside Omarchy's
 
 Shibumi V2 consumes the same Omarchy bar layout and hosts OmaQ without a separate integration path. Shibumi V1 adoption of newly enabled third-party widgets remains a Shibumi compatibility boundary rather than an OmaQ-specific installer action.
 
-If installation fails and `.omaq-source-install` remains in your home directory, inspect the reported error before removing that path and starting again. The command refuses to reuse the retained checkout. Successfully installed dependency packages remain available.
+If `.omaq-source-install` remains after a failure, inspect the error, then remove it with `rm -rf -- "$HOME/.omaq-source-install"`. If the error says the installed tree remains, do not rerun this command; follow the reported recovery state. Successfully installed dependency packages remain available.
 
 The short command trusts the user's Git configuration and environment, including URL rewrites, proxies, credential helpers, and TLS settings; it does not independently prove before execution that the checkout came from public GitHub. Use the following bootstrap when acquisition must ignore user Git configuration, bind a reviewed commit before execution, and enforce resource limits.
 

--- a/install.sh
+++ b/install.sh
@@ -84,28 +84,18 @@ installer="$root/scripts/install-omaq.sh"
 [ -f "$installer" ] && [ -x "$installer" ] && [ ! -L "$installer" ] ||
   fail "verified source installer is unavailable: $installer"
 
-if [ -n "$expected_commit" ] && [ -n "$section" ]; then
-  "$installer" --preflight-only --expect-commit "$expected_commit" \
-    --section "$section" --yes
-elif [ -n "$expected_commit" ]; then
-  "$installer" --preflight-only --expect-commit "$expected_commit" --yes
-elif [ -n "$section" ]; then
-  "$installer" --preflight-only --section "$section" --yes
-else
-  "$installer" --preflight-only --yes
+set -- --yes
+if [ -n "$section" ]; then
+  set -- --section "$section" "$@"
 fi
+if [ -n "$expected_commit" ]; then
+  set -- --expect-commit "$expected_commit" "$@"
+fi
+
+"$installer" --preflight-only "$@"
 
 PATH=/usr/bin:/bin /usr/bin/omarchy pkg add \
   toxcore libsignal-protocol-c libpulse libpng libjpeg-turbo libwebp \
   ttf-material-symbols-variable qrencode
 
-if [ -n "$expected_commit" ] && [ -n "$section" ]; then
-  exec "$installer" --expect-commit "$expected_commit" \
-    --section "$section" --yes
-elif [ -n "$expected_commit" ]; then
-  exec "$installer" --expect-commit "$expected_commit" --yes
-elif [ -n "$section" ]; then
-  exec "$installer" --section "$section" --yes
-else
-  exec "$installer" --yes
-fi
+exec "$installer" "$@"

--- a/tests/source-install.py
+++ b/tests/source-install.py
@@ -220,6 +220,7 @@ class SourceInstallTests(unittest.TestCase):
             "network_parent = os.path.dirname(network_home)",
             '"HOME": network_home',
             '"GIT_CEILING_DIRECTORIES": network_parent',
+            '"/usr/bin/git", "-c", "core.hooksPath=/dev/null"',
             '"-c", "credential.helper="',
             '"-c", "http.extraHeader="',
             "env=env, cwd=network_home",

--- a/tests/update-order.sh
+++ b/tests/update-order.sh
@@ -36,8 +36,12 @@ cmp -s "$tmp/readme-install.sh" "$tmp/installation-install.sh" || {
 # shellcheck disable=SC2016
 grep -Fq 'mkdir -m 700 -- "$HOME/.omaq-source-install"' \
   "$tmp/readme-install.sh"
-grep -Fq '/usr/bin/git clone --no-hardlinks --branch main --single-branch --' \
+grep -Eq '^git clone --no-hardlinks --branch main --single-branch -- \\$' \
   "$tmp/readme-install.sh"
+if grep -Fq '/usr/bin/git clone' "$tmp/readme-install.sh"; then
+  echo "update-order: convenience install no longer uses user Git" >&2
+  exit 1
+fi
 grep -Fq 'https://github.com/HANCORE-linux/OmaQ.git' \
   "$tmp/readme-install.sh"
 # shellcheck disable=SC2016
@@ -49,8 +53,7 @@ if grep -Fq 'omarchy pkg add' "$tmp/readme-install.sh" ||
   echo "update-order: primary install bypasses the root installer" >&2
   exit 1
 fi
-sed "s#/usr/bin/git#$tmp/bin/git#g" "$tmp/readme-install.sh" \
-  >"$tmp/readme-install-test.sh"
+cp "$tmp/readme-install.sh" "$tmp/readme-install-test.sh"
 
 extract_block "## Update" "$root/README.md" >"$tmp/readme-update.sh"
 extract_block "## Update OmaQ" "$root/docs/INSTALLATION.md" >"$tmp/installation-update.sh"
@@ -354,6 +357,11 @@ grep -Fq '<summary>Pin a reviewed commit and limit acquisition</summary>' \
   echo "update-order: bounded bootstrap is not an optional detail" >&2
   exit 1
 }
+grep -Fq '"/usr/bin/git", "-c", "core.hooksPath=/dev/null"' \
+  "$root/docs/INSTALLATION.md" || {
+  echo "update-order: bounded bootstrap does not bind system Git" >&2
+  exit 1
+}
 
 if grep -Eq '<sub>|<br[ >]' "$root/README.md"; then
   echo "update-order: README introduction changes the subtitle size or line" >&2
@@ -379,6 +387,15 @@ grep -Fq 'the updater builds outside the monitored plugin tree' \
 if grep -Fq 'The updater returns without staging or stopping the shell' \
     "$root/README.md"; then
   echo "update-order: verbose README update explanation remains" >&2
+  exit 1
+fi
+grep -Fq 'This installs OmaQ and its dependencies in the right bar section.' \
+  "$root/README.md" || {
+  echo "update-order: concise README install summary is missing" >&2
+  exit 1
+}
+if grep -Fq 'builds the omitted Signal-enabled' "$root/README.md"; then
+  echo "update-order: verbose README install explanation remains" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- reduce the README installation explanation to two short sentences
- use the user's `git` command in the explicitly user-config-trusting convenience path
- construct installer arguments once for preflight and final execution
- distinguish retained external checkout recovery from retained installed-tree recovery
- pin the convenience and bounded Git command surfaces in regression tests

## Validation

- `make test`
- 42 source-updater tests
- 23 source-installer tests
- Bash and Fish documented-install harnesses
- `make arch`
- `omarchy plugin validate .`
- ShellCheck and shell syntax checks
- Python syntax checks
- GitHub Markdown rendering check
- `git diff --check`
- independent AppSec/code review: no findings

No live installation or helper was changed by this branch.
