### PR TITLE
Fix audit lifecycle and architecture gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ test: $(BIN_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TES
 	@if [ "$(TOX_OK)" = "yes" ]; then ./$(BIN_TOX_RELAY_RETRY_TEST); fi
 	@if [ "$(SIG_OK)" = "yes" ]; then ./$(BIN_RATCHET_PREKEY_TEST); fi
 	python3 tests/tcp_relay_retry_source_test.py
+	sh tests/arch-check.sh
 	sh tests/float-script.sh
 	sh tests/nonblocking-invite.sh
 	sh tests/input-mask.sh

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -47,7 +47,27 @@ Start a Bash session, set `install_section` to the preferred bar section, then s
   esac
   bootstrap=$(/usr/bin/mktemp -d \
     "$state_home/omaq-source-bootstrap.XXXXXX")
-  trap '/usr/bin/rm -rf -- "$bootstrap" "${bootstrap}.network-home"' EXIT
+  cleanup_bootstrap() {
+    status=$?
+    trap - EXIT
+    if (( status == 0 )); then
+      /usr/bin/rm -rf -- "$bootstrap" "${bootstrap}.network-home" || status=$?
+    else
+      if [[ -d $bootstrap ]]; then
+        printf 'Bootstrap failed; retained temporary checkout at %s\n' \
+          "$bootstrap" >&2 || :
+      else
+        printf '%s\n' \
+          'Bootstrap failed after checkout placement; follow the installer recovery diagnostic above.' >&2 || :
+      fi
+      if [[ -d ${bootstrap}.network-home ]]; then
+        printf 'Retained isolated network home at %s\n' \
+          "${bootstrap}.network-home" >&2 || :
+      fi
+    fi
+    exit "$status"
+  }
+  trap cleanup_bootstrap EXIT
   /usr/bin/python3 -I - "$bootstrap" "$expected_commit" <<'PY'
 import os, re, resource, shutil, signal, stat, subprocess, sys, time
 
@@ -233,11 +253,11 @@ PY
 )
 ```
 
-The bootstrap uses an isolated credential-free home for anonymous public GitHub access, limits clone size and command output, and terminates the process group after a timeout or limit failure. It rejects a changed canonical ref before cloning or executing downloaded code. The installer repeats the commit check before and after the build.
+The bootstrap uses an isolated credential-free home for anonymous public GitHub access, limits clone size and command output, and terminates the process group after a timeout or limit failure. It rejects a changed canonical ref before cloning or executing downloaded code. The installer repeats the commit check before and after the build. Successful runs remove the temporary checkout and network home. Failed runs retain and print any temporary paths that still exist; remove them manually after inspection. If failure happens after checkout placement, follow the installer's live-tree recovery diagnostic instead.
 
 </details>
 
-The installer validates the complete Git checkout, builds the helper outside the monitored plugin tree, stops the shell, and places the checkout with `renameat2(RENAME_NOREPLACE)`. It then restarts the shell, waits for startup discovery, and enables OmaQ once. See the [source installation transaction](stages/safe-source-install.md) for security boundaries and failure recovery.
+The external installer used by that bootstrap validates the complete Git checkout, builds the helper outside the monitored plugin tree, stops the shell, and places the checkout with `renameat2(RENAME_NOREPLACE)`. It then restarts the shell, waits for startup discovery, and enables OmaQ once. See the [source installation transaction](stages/safe-source-install.md) for security boundaries and failure recovery.
 
 Verify the plugin and helper after installation:
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -75,7 +75,7 @@ Second review (hexagonal / seams):
 | — | This is hexagonal, not full Clean Architecture — and that is right | **Use.** No rings, no Vtables. |
 | 1 | Split `roles.c` (pure) from `group.c` | **Use.** Gold in `verify-1-offline`. |
 | 2 | flock belongs in the helper; Service only exec + connect | **Use.** Verified: Quickshell.Io has Process, Socket, FileView — no flock. |
-| 3 | `make arch` grep as a mechanical Dependency Rule | **Use.** In `verify-0`. |
+| 3 | `make arch` grep as a textual direct-dependency guard | **Use.** In `verify-0`; aliases, macros, and indirect calls still require review. |
 | 4 | `message` vs `store` — `store.h` seam | **Use.** |
 | 5 | `surfaces.json` has no owner | **Use helper ownership.** `surface.set`/`get`. Discard QML last-writer-wins. |
 | 6 | sanitizers + mutation corpus on `json_io` / invite | **Use.** Discard a full fuzzing product in phase 0. |
@@ -145,16 +145,16 @@ ChatSurface.qml                # unpinned overlay + pinned terminal window
 
 New capability = new module + new `op`/`event` **and** a gold test, then code.
 
-**Mechanical (not prose):** `make arch` in `verify-0` (~grep):
+**Textual guard (not a complete parser):** `make arch` in `verify-0` rejects these source patterns:
 
 - only `tox_adapt.c` may include `<tox/tox.h>`, `<tox/toxav.h>`, or `<tox/toxencryptsave.h>`
 - only `ratchet_adapt.c` may include Signal protocol headers (`<signal/…>`)
 - only `store.c` may open `$OMAQ_HOME/history`
-- `roles.c`, `invite.c`, `conversation.c` contain no `open(`, `fopen`, `socket`, `tox_`
+- pure-policy modules contain no complete `open`, `fopen`, or `socket` identifier tokens and no direct toxcore references
 - `Model.js` contains no `Qt`, `Quickshell`, `XMLHttpRequest`
 - no QML file contains `tox`
 
-Do not put domain rules in QML. Do not invert the arrow. `make arch` fails the build if that erodes.
+Do not put domain rules in QML. Do not invert the arrow. `make arch` rejects the include, path, and identifier patterns above; review remains responsible for aliases, macros, indirect calls, and semantic dependency flow.
 
 This is hexagonal / ports-and-adapters. Not four-ring Clean Architecture: no DI container, no Vtables, one UI, one file store. The process boundary is the main port.
 
@@ -425,7 +425,7 @@ omaq/
   pages/
   helper/
   tests/gold/invite/ tests/gold/json/ tests/gold/store/
-  tests/run.sh
+  tests/*.sh tests/*.py     # native, fixture, lifecycle, and source checks
   tests/two-clients.sh      # two socket clients, assert one helper
   packaging/PKGBUILD
   docs/PLAN.md

--- a/scripts/arch-check.sh
+++ b/scripts/arch-check.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Mechanical architecture law. Fail if a layer leak appears.
+# Textual guard for architecture leaks. This is not a complete C parser:
+# aliases, macros, and indirect calls still require review.
 # Missing files are not failures (phase 0 has no helper sources yet).
 
 set -eu
@@ -40,12 +41,27 @@ if [ -d helper ]; then
 	fi
 fi
 
-# Pure policy: no IO, no tox.
+# Pure policy: conservatively reject complete IO identifier tokens. This catches
+# whitespace-, comment-, newline-, and parenthesis-separated direct calls.
+policy_io_pattern='(^|[^[:alnum:]_])(open|fopen|socket)([^[:alnum:]_]|$)'
+for sample in 'fopen("file", "r")' 'fopen ("file", "r")' \
+	'fopen/*comment*/("file", "r")' '(fopen)("file", "r")' \
+	'open("file", 0)' 'open ("file", 0)' 'socket(0, 0, 0)' 'socket (0, 0, 0)'; do
+	if ! printf '%s\n' "$sample" | grep -Eq "$policy_io_pattern"; then
+		die "pure-policy IO matcher missed fixture: $sample"
+	fi
+done
+if ! printf 'fopen\n("file", "r")\n' | grep -Eq "$policy_io_pattern"; then
+	die "pure-policy IO matcher missed a newline-separated fixture"
+fi
+if printf '%s\n' 'void my_fopen (void);' | grep -Eq "$policy_io_pattern"; then
+	die "pure-policy IO matcher rejected an identifier suffix"
+fi
 for f in helper/roles.c helper/invite.c helper/conversation.c helper/rate.c helper/safety.c; do
 	[ -f "$f" ] || continue
-	if grep -En '([^[:alnum:]_](open|fopen|socket)\()' "$f" >/dev/null; then
-		die "$f contains IO"
-		grep -En '([^[:alnum:]_](open|fopen|socket)\()' "$f" >&2 || true
+	if grep -En "$policy_io_pattern" "$f" >/dev/null; then
+		die "$f contains direct IO"
+		grep -En "$policy_io_pattern" "$f" >&2 || true
 	fi
 	if grep -En '#include[[:space:]]*[<"]tox/|tox_friend|tox_new|tox_iterate|tox_group' "$f" >/dev/null; then
 		die "$f talks to toxcore"

--- a/tests/arch-check.sh
+++ b/tests/arch-check.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d /tmp/omaq-arch-check-XXXXXX)
+# shellcheck disable=SC2329 # Invoked by the EXIT trap.
+cleanup() { rm -rf -- "$tmp"; }
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$tmp/helper" "$tmp/scripts"
+cp "$root/scripts/arch-check.sh" "$tmp/scripts/arch-check.sh"
+for path in install.sh scripts/float-omaq.sh scripts/uninstall-omaq.sh \
+  scripts/paste-image.sh scripts/update-helper.sh scripts/helper-runtime.py \
+  scripts/install-omaq.sh scripts/install-omaq.py scripts/update-omaq.sh \
+  scripts/update-omaq.py; do
+  mkdir -p -- "$(dirname "$tmp/$path")"
+  printf '#!/bin/sh\nexit 0\n' >"$tmp/$path"
+  chmod 0755 "$tmp/$path"
+done
+
+printf '%s\n' 'void policy_without_io(void) {}' >"$tmp/helper/roles.c"
+sh "$tmp/scripts/arch-check.sh" >/dev/null
+
+cat >"$tmp/helper/roles.c" <<'EOF'
+#include <stdio.h>
+void audit_forbidden_io(void) {
+  FILE *file = fopen ("/tmp/unused", "r");
+  if (file)
+    fclose(file);
+}
+EOF
+set +e
+output=$(sh "$tmp/scripts/arch-check.sh" 2>&1)
+status=$?
+set -e
+if [ "$status" -ne 1 ] ||
+   ! printf '%s\n' "$output" | grep -Fq 'helper/roles.c contains direct IO'; then
+  printf '%s\n' "$output" >&2
+  echo "arch-check: policy IO mutation passed" >&2
+  exit 1
+fi
+
+echo "arch-check: ok"

--- a/tests/encryptsave.sh
+++ b/tests/encryptsave.sh
@@ -11,6 +11,7 @@ sa=$(mktemp -d /tmp/omaq-encs-XXXXXX)
 out=$(mktemp /tmp/omaq-enco-XXXXXX)
 hold=$(mktemp -u /tmp/omaq-encf-XXXXXX)
 pid=""
+# shellcheck disable=SC2329 # Invoked by the EXIT trap.
 cleanup() {
 	exec 3>&- 2>/dev/null || true
 	[ -n "${pid:-}" ] && kill "$pid" 2>/dev/null || true

--- a/tests/lock-elect.sh
+++ b/tests/lock-elect.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 # Two helpers, one home: exactly one keeps the lock. No network, no toxcore.
 set -eu
-root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 bin="$root/helper/omaq"
 [ -x "$bin" ] || { echo "lock-elect: missing helper/omaq" >&2; exit 1; }
 
 real_home="${HOME}/.local/share/omaq"
 home=$(mktemp -d /tmp/omaq-lock-XXXXXX)
 state=$(mktemp -d /tmp/omaq-state-XXXXXX)
+# shellcheck disable=SC2329 # Invoked by the EXIT trap.
 cleanup() { kill "$pid" 2>/dev/null || true; rm -rf "$home" "$state"; }
 trap cleanup EXIT
 

--- a/tests/source-install.py
+++ b/tests/source-install.py
@@ -232,6 +232,102 @@ class SourceInstallTests(unittest.TestCase):
             bootstrap.index("os.mkdir(network_home, mode=0o700)"),
             bootstrap.index('[*git, "ls-remote"'),
         )
+        self.assertNotIn(
+            "trap '/usr/bin/rm -rf -- \"$bootstrap\"",
+            documentation,
+        )
+
+    def test_documented_bootstrap_cleanup_retains_failures_only(self):
+        documentation = (ROOT / "docs/INSTALLATION.md").read_text(encoding="utf-8")
+        function_start = documentation.index("  cleanup_bootstrap() {\n")
+        trap_line = "  trap cleanup_bootstrap EXIT\n"
+        function_end = documentation.index(trap_line, function_start) + len(trap_line)
+        cleanup = documentation[function_start:function_end]
+
+        with tempfile.TemporaryDirectory() as parent:
+            failed_checkout = Path(parent) / "failed checkout"
+            failed_network_home = Path(f"{failed_checkout}.network-home")
+            failed_checkout.mkdir()
+            failed_network_home.mkdir()
+            failed = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    f"set -euo pipefail\nbootstrap=$1\n{cleanup}\nexit 42\n",
+                    "bootstrap-cleanup-test",
+                    str(failed_checkout),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(failed.returncode, 42)
+            self.assertTrue(failed_checkout.is_dir())
+            self.assertTrue(failed_network_home.is_dir())
+            self.assertIn(
+                f"retained temporary checkout at {failed_checkout}",
+                failed.stderr,
+            )
+
+            closed_checkout = Path(parent) / "closed stderr checkout"
+            closed_network_home = Path(f"{closed_checkout}.network-home")
+            closed_checkout.mkdir()
+            closed_network_home.mkdir()
+            closed = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    f"set -euo pipefail\nbootstrap=$1\n{cleanup}\nexec 2>&-\nexit 42\n",
+                    "bootstrap-cleanup-test",
+                    str(closed_checkout),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            self.assertEqual(closed.returncode, 42)
+            self.assertTrue(closed_checkout.is_dir())
+            self.assertTrue(closed_network_home.is_dir())
+
+            placed_checkout = Path(parent) / "placed checkout"
+            placed = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    f"set -euo pipefail\nbootstrap=$1\n{cleanup}\nexit 23\n",
+                    "bootstrap-cleanup-test",
+                    str(placed_checkout),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(placed.returncode, 23)
+            self.assertNotIn("retained temporary checkout", placed.stderr)
+            self.assertIn("failed after checkout placement", placed.stderr)
+
+            successful_checkout = Path(parent) / "successful checkout"
+            successful_network_home = Path(f"{successful_checkout}.network-home")
+            successful_checkout.mkdir()
+            successful_network_home.mkdir()
+            succeeded = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    f"set -euo pipefail\nbootstrap=$1\n{cleanup}\ntrue\n",
+                    "bootstrap-cleanup-test",
+                    str(successful_checkout),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(succeeded.returncode, 0, succeeded.stderr)
+            self.assertFalse(successful_checkout.exists())
+            self.assertFalse(successful_network_home.exists())
 
     def test_public_bootstrap_home_does_not_send_netrc_credentials(self):
         class CredentialHandler(http.server.BaseHTTPRequestHandler):

--- a/tests/two-clients.sh
+++ b/tests/two-clients.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Two Unix-socket clients, one helper. No network required.
 set -eu
-root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 bin="$root/helper/omaq"
 [ -x "$bin" ] || { echo "two-clients: missing helper/omaq" >&2; exit 1; }
 
@@ -11,6 +11,7 @@ state=$(mktemp -d /tmp/omaq-2cs-XXXXXX)
 hold=$(mktemp -u /tmp/omaq-2cf-XXXXXX)
 out=$(mktemp /tmp/omaq-2co-XXXXXX)
 pid=""
+# shellcheck disable=SC2329 # Invoked by the EXIT trap.
 cleanup() {
 	exec 3>&- 2>/dev/null || true
 	[ -n "${pid:-}" ] && kill "$pid" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- retain existing external-bootstrap diagnostics on failure while preserving the original exit status
- distinguish pre-placement checkout retention from post-placement live-tree recovery
- broaden the textual architecture guard to reject complete direct-I/O identifiers across whitespace, comments, newlines, and parenthesized forms
- add an end-to-end architecture mutation regression
- correct installation/plan wording and resolve the audited ShellCheck findings

## Validation

- isolated `make verify-4`
- `python3 tests/source-install.py` (27 tests)
- `sh tests/arch-check.sh`
- `make arch`
- repository-wide ShellCheck
- `omarchy plugin validate .`
- `git diff --check`

## Limitations

- the architecture gate remains an intentionally conservative textual check; aliases, macros, preprocessing tricks, indirect calls, and semantic dependency flow still require review
- the Quickshell/Wayland runtime fixture was unavailable and skipped; no native live-install acceptance is claimed
