### PR TITLE
security: widen the relay set and add fail-closed SOCKS5/HTTP proxy and user relay support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 LIB_SRC := helper/invite.c helper/roles.c helper/conversation.c helper/auto_open.c \
 	helper/group_file.c helper/group_file_store.c helper/json_io.c helper/text.c helper/line_reader.c helper/stdout_spool.c helper/state_archive.c helper/store.c helper/message.c \
 	helper/identity.c helper/identity_guard.c helper/tox_adapt.c helper/rate.c \
-	helper/safety.c helper/proxy.c helper/qr.c helper/group.c helper/group_invite.c \
+	helper/safety.c helper/proxy.c helper/relays.c helper/qr.c helper/group.c helper/group_invite.c \
 	helper/surface.c helper/sound.c helper/file.c helper/avatar.c helper/av.c \
 	helper/presence.c helper/receipt.c helper/message_action.c helper/direct_state.c \
 	helper/ratchet.c helper/ratchet_pin.c helper/ratchet_adapt.c
@@ -51,7 +51,7 @@ HELPER_SRC := $(LIB_SRC) helper/omaq.c
 TEST_SRC := tests/omaq_test.c helper/invite.c helper/roles.c helper/conversation.c helper/auto_open.c \
 	helper/group_file.c helper/group_file_store.c helper/json_io.c helper/text.c helper/line_reader.c helper/store.c helper/message.c helper/identity.c \
 	helper/identity_guard.c \
-	helper/rate.c helper/safety.c helper/proxy.c helper/qr.c helper/group.c helper/group_invite.c \
+	helper/rate.c helper/safety.c helper/proxy.c helper/relays.c helper/qr.c helper/group.c helper/group_invite.c \
 	helper/surface.c helper/sound.c helper/state_archive.c helper/file.c helper/avatar.c helper/presence.c helper/receipt.c helper/message_action.c \
 	helper/direct_state.c helper/ratchet.c helper/ratchet_pin.c
 
@@ -111,17 +111,17 @@ $(BIN_RATCHET_PREKEY_TEST): tests/ratchet_prekey_test.c helper/ratchet.c helper/
 		tests/ratchet_prekey_test.c helper/ratchet.c helper/ratchet_adapt.c \
 		$(shell $(PKG_CONFIG) --libs libsignal-protocol-c libcrypto)
 
-$(BIN_IDENTITY_GUARD_TEST): tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c helper/proxy.c
+$(BIN_IDENTITY_GUARD_TEST): tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c helper/proxy.c helper/relays.c
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DHAVE_TOX -DOMAQ_TOX_TEST \
 		-DOMAQ_IDENTITY_GUARD_TEST \
 		$(shell $(PKG_CONFIG) --cflags $(TOX_PC)) -o $@ \
-		tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c helper/proxy.c \
+		tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c helper/proxy.c helper/relays.c \
 		$(shell $(PKG_CONFIG) --libs $(TOX_PC))
 
-$(BIN_TOX_RELAY_RETRY_TEST): tests/tox_relay_retry_test.c helper/tox_adapt.c helper/identity_guard.c helper/file.c helper/proxy.c
+$(BIN_TOX_RELAY_RETRY_TEST): tests/tox_relay_retry_test.c helper/tox_adapt.c helper/identity_guard.c helper/file.c helper/proxy.c helper/relays.c
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DHAVE_TOX \
 		$(shell $(PKG_CONFIG) --cflags $(TOX_PC)) -o $@ \
-		tests/tox_relay_retry_test.c helper/identity_guard.c helper/file.c helper/proxy.c \
+		tests/tox_relay_retry_test.c helper/identity_guard.c helper/file.c helper/proxy.c helper/relays.c \
 		-Wl,--wrap=tox_bootstrap -Wl,--wrap=tox_add_tcp_relay \
 		$(shell $(PKG_CONFIG) --libs $(TOX_PC))
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 LIB_SRC := helper/invite.c helper/roles.c helper/conversation.c helper/auto_open.c \
 	helper/group_file.c helper/group_file_store.c helper/json_io.c helper/text.c helper/line_reader.c helper/stdout_spool.c helper/state_archive.c helper/store.c helper/message.c \
 	helper/identity.c helper/identity_guard.c helper/tox_adapt.c helper/rate.c \
-	helper/safety.c helper/qr.c helper/group.c helper/group_invite.c \
+	helper/safety.c helper/proxy.c helper/qr.c helper/group.c helper/group_invite.c \
 	helper/surface.c helper/sound.c helper/file.c helper/avatar.c helper/av.c \
 	helper/presence.c helper/receipt.c helper/message_action.c helper/direct_state.c \
 	helper/ratchet.c helper/ratchet_pin.c helper/ratchet_adapt.c
@@ -51,7 +51,7 @@ HELPER_SRC := $(LIB_SRC) helper/omaq.c
 TEST_SRC := tests/omaq_test.c helper/invite.c helper/roles.c helper/conversation.c helper/auto_open.c \
 	helper/group_file.c helper/group_file_store.c helper/json_io.c helper/text.c helper/line_reader.c helper/store.c helper/message.c helper/identity.c \
 	helper/identity_guard.c \
-	helper/rate.c helper/safety.c helper/qr.c helper/group.c helper/group_invite.c \
+	helper/rate.c helper/safety.c helper/proxy.c helper/qr.c helper/group.c helper/group_invite.c \
 	helper/surface.c helper/sound.c helper/state_archive.c helper/file.c helper/avatar.c helper/presence.c helper/receipt.c helper/message_action.c \
 	helper/direct_state.c helper/ratchet.c helper/ratchet_pin.c
 
@@ -111,17 +111,17 @@ $(BIN_RATCHET_PREKEY_TEST): tests/ratchet_prekey_test.c helper/ratchet.c helper/
 		tests/ratchet_prekey_test.c helper/ratchet.c helper/ratchet_adapt.c \
 		$(shell $(PKG_CONFIG) --libs libsignal-protocol-c libcrypto)
 
-$(BIN_IDENTITY_GUARD_TEST): tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c
+$(BIN_IDENTITY_GUARD_TEST): tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c helper/proxy.c
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DHAVE_TOX -DOMAQ_TOX_TEST \
 		-DOMAQ_IDENTITY_GUARD_TEST \
 		$(shell $(PKG_CONFIG) --cflags $(TOX_PC)) -o $@ \
-		tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c \
+		tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c helper/proxy.c \
 		$(shell $(PKG_CONFIG) --libs $(TOX_PC))
 
-$(BIN_TOX_RELAY_RETRY_TEST): tests/tox_relay_retry_test.c helper/tox_adapt.c helper/identity_guard.c helper/file.c
+$(BIN_TOX_RELAY_RETRY_TEST): tests/tox_relay_retry_test.c helper/tox_adapt.c helper/identity_guard.c helper/file.c helper/proxy.c
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DHAVE_TOX \
 		$(shell $(PKG_CONFIG) --cflags $(TOX_PC)) -o $@ \
-		tests/tox_relay_retry_test.c helper/identity_guard.c helper/file.c \
+		tests/tox_relay_retry_test.c helper/identity_guard.c helper/file.c helper/proxy.c \
 		-Wl,--wrap=tox_bootstrap -Wl,--wrap=tox_add_tcp_relay \
 		$(shell $(PKG_CONFIG) --libs $(TOX_PC))
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -882,6 +882,10 @@ BarWidget {
       return "The invite could not be added. Create a fresh invite and try it once on the other device."
     if (code === "nospam_rotate_failed")
       return "The invite was cleared, but its one-use address could not be refreshed."
+    if (code === "proxy_invalid")
+      return "proxy.conf in the OmaQ data folder is unreadable or malformed. OmaQ will not connect without the proxy you configured. Fix or remove the file, then restart OmaQ."
+    if (code === "relays_invalid")
+      return "relays.conf in the OmaQ data folder is unreadable or malformed. OmaQ will not connect through relays you did not choose. Fix or remove the file, then restart OmaQ."
     if (code === "safety_key_changed")
       return "This contact's encryption identity changed. Remove the old contact state on both devices before exchanging a fresh invite."
     if (code === "group_registry_failed")

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,13 @@ Private Tox New Group Chats use Tox group transport. Group attachments use authe
 
 OmaQ keeps Tox in Transmission Control Protocol (TCP) relay privacy mode. It disables direct User Datagram Protocol (UDP) discovery, local discovery, and hole punching. Contacts therefore do not receive each other's IP addresses through direct Tox connections.
 
-OmaQ connects to public bootstrap and relay nodes run by Tox community volunteers. These nodes help peers discover the network and forward encrypted packets. They cannot read message contents, but relay operators can observe ordinary connection metadata.
+OmaQ connects to public bootstrap and relay nodes run by Tox community volunteers. These nodes help peers discover the network and forward encrypted packets. They cannot read message contents, but relay operators can observe ordinary connection metadata. Because direct UDP is disabled, every packet crosses a relay, so OmaQ spreads its pinned relay set across independent operators: no single operator sees all of a user's traffic, and losing one relay does not remove connectivity.
+
+The address hidden from contacts is still visible to relay operators. To close that gap, route OmaQ through a SOCKS5 or HTTP proxy — for example a local Tor SOCKS port — by creating `~/.local/share/omaq/proxy.conf` with a single directive:
+
+    socks5 127.0.0.1 9050
+
+Use `http <host> <port>` for an HTTP proxy, or `none` to disable. Lines beginning with `#` are comments. The helper fails closed: if the file exists but is malformed, unreadable, a symlink, or group/other-writable, OmaQ refuses to start rather than connecting directly and exposing the address the proxy was meant to hide. Restart OmaQ after editing the file.
 
 OmaQ runs no project-operated server, account service, or recovery service. The project author cannot access, intercept, recover, or delete your messages, identity, or contacts.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -22,6 +22,13 @@ The address hidden from contacts is still visible to relay operators. To close t
 
 Use `http <host> <port>` for an HTTP proxy, or `none` to disable. Lines beginning with `#` are comments. The helper fails closed: if the file exists but is malformed, unreadable, a symlink, or group/other-writable, OmaQ refuses to start rather than connecting directly and exposing the address the proxy was meant to hide. Restart OmaQ after editing the file.
 
+To choose the relays themselves, create `~/.local/share/omaq/relays.conf` with one `<host> <udp-port> <tcp-port> <64-hex-public-key>` line per relay (up to 16):
+
+    # your own tox-bootstrapd
+    relay.example.org 33445 443 7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C
+
+These relays are used in addition to the pinned set. Add a line containing only `exclusive` to use *only* the listed relays, which removes the public relay operators from the path entirely. Public keys are required and pinned exactly as the built-in ones are. This file fails closed the same way: a malformed, unreadable, symlinked, or group/other-writable `relays.conf` stops OmaQ instead of quietly falling back to relays you chose to avoid.
+
 OmaQ runs no project-operated server, account service, or recovery service. The project author cannot access, intercept, recover, or delete your messages, identity, or contacts.
 
 ## Protect local data

--- a/helper/omaq.c
+++ b/helper/omaq.c
@@ -10142,6 +10142,15 @@ static int load_tox(const char *pass)
 		emit_error("proxy_invalid");
 		return -1;
 	}
+	if (err == OMAQ_TOX_RELAYS_INVALID) {
+		/* Fail closed: never fall back to relays the user chose to replace. */
+		fprintf(stderr,
+			"omaq: %s/relays.conf is unreadable or malformed; "
+			"refusing to connect through unintended relays\n",
+			home_dir());
+		emit_error("relays_invalid");
+		return -1;
+	}
 	g_locked = 0;
 	if (!g_tox) {
 		if (g_identity_guard_state == OMAQ_IDENTITY_GUARD_RESTORED)

--- a/helper/omaq.c
+++ b/helper/omaq.c
@@ -10133,6 +10133,15 @@ static int load_tox(const char *pass)
 		g_locked = 1;
 		return 1;
 	}
+	if (err == OMAQ_TOX_PROXY_INVALID) {
+		/* Fail closed: never connect directly when a proxy was requested. */
+		fprintf(stderr,
+			"omaq: %s/proxy.conf is unreadable or malformed; "
+			"refusing to connect without the requested proxy\n",
+			home_dir());
+		emit_error("proxy_invalid");
+		return -1;
+	}
 	g_locked = 0;
 	if (!g_tox) {
 		if (g_identity_guard_state == OMAQ_IDENTITY_GUARD_RESTORED)

--- a/helper/proxy.c
+++ b/helper/proxy.c
@@ -1,0 +1,172 @@
+#define _DEFAULT_SOURCE
+#include "proxy.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int host_char_ok(char c)
+{
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+	       (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_' ||
+	       c == ':';
+}
+
+static int host_ok(const char *host, size_t n)
+{
+	size_t i;
+
+	if (n == 0 || n >= OMAQ_PROXY_HOST_MAX)
+		return 0;
+	for (i = 0; i < n; i++) {
+		if (!host_char_ok(host[i]))
+			return 0;
+	}
+	return 1;
+}
+
+static int parse_port(const char *text, size_t n, unsigned *out)
+{
+	unsigned value = 0;
+	size_t i;
+
+	if (n == 0 || n > 5)
+		return -1;
+	for (i = 0; i < n; i++) {
+		if (text[i] < '0' || text[i] > '9')
+			return -1;
+		value = value * 10u + (unsigned)(text[i] - '0');
+	}
+	if (value == 0 || value > 65535u)
+		return -1;
+	*out = value;
+	return 0;
+}
+
+static size_t token(const char *line, size_t from, size_t length, size_t *end)
+{
+	size_t start = from;
+
+	while (start < length && (line[start] == ' ' || line[start] == '\t'))
+		start++;
+	*end = start;
+	while (*end < length && line[*end] != ' ' && line[*end] != '\t')
+		(*end)++;
+	return start;
+}
+
+static int parse_directive(const char *line, size_t length, omaq_proxy *out)
+{
+	size_t start, end, next_start, next_end;
+	omaq_proxy parsed;
+
+	memset(&parsed, 0, sizeof(parsed));
+	start = token(line, 0, length, &end);
+	if (start == end)
+		return -1;
+	if (end - start == 4 && memcmp(line + start, "none", 4) == 0) {
+		parsed.type = OMAQ_PROXY_NONE;
+		next_start = token(line, end, length, &next_end);
+		if (next_start != next_end)
+			return -1;
+		*out = parsed;
+		return 0;
+	}
+	if (end - start == 6 && memcmp(line + start, "socks5", 6) == 0)
+		parsed.type = OMAQ_PROXY_SOCKS5;
+	else if (end - start == 4 && memcmp(line + start, "http", 4) == 0)
+		parsed.type = OMAQ_PROXY_HTTP;
+	else
+		return -1;
+
+	start = token(line, end, length, &end);
+	if (start == end || !host_ok(line + start, end - start))
+		return -1;
+	memcpy(parsed.host, line + start, end - start);
+	parsed.host[end - start] = '\0';
+
+	start = token(line, end, length, &end);
+	if (start == end || parse_port(line + start, end - start, &parsed.port) != 0)
+		return -1;
+
+	/* Nothing may follow the port: an unparsed trailing field would mean the
+	 * file says something the helper is not honouring. */
+	next_start = token(line, end, length, &next_end);
+	if (next_start != next_end)
+		return -1;
+	*out = parsed;
+	return 0;
+}
+
+int omaq_proxy_parse(const char *text, omaq_proxy *out)
+{
+	const char *cursor;
+	omaq_proxy parsed;
+	int found = 0;
+
+	if (!text || !out)
+		return -1;
+	memset(&parsed, 0, sizeof(parsed));
+	cursor = text;
+	while (*cursor) {
+		const char *newline = strchr(cursor, '\n');
+		size_t length = newline ? (size_t)(newline - cursor) : strlen(cursor);
+		size_t start, end;
+
+		if (length > 0 && cursor[length - 1] == '\r')
+			length--;
+		start = token(cursor, 0, length, &end);
+		if (start != end && cursor[start] != '#') {
+			if (found)
+				return -1; /* one directive only */
+			if (parse_directive(cursor, length, &parsed) != 0)
+				return -1;
+			found = 1;
+		}
+		if (!newline)
+			break;
+		cursor = newline + 1;
+	}
+	if (!found)
+		return -1;
+	*out = parsed;
+	return 0;
+}
+
+int omaq_proxy_load(const char *home, omaq_proxy *out)
+{
+	char path[512];
+	char body[OMAQ_PROXY_FILE_MAX + 1];
+	struct stat st;
+	ssize_t got;
+	int fd;
+
+	if (!home || !out)
+		return -1;
+	if (snprintf(path, sizeof(path), "%s/proxy.conf", home) >= (int)sizeof(path))
+		return -1;
+	fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK);
+	/* Only a genuinely absent file means "no proxy". A symlink (ELOOP under
+	 * O_NOFOLLOW) or any other error fails closed. */
+	if (fd < 0)
+		return errno == ENOENT ? 0 : -1;
+	if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_uid != geteuid() ||
+	    st.st_nlink != 1 || (st.st_mode & 0022) ||
+	    st.st_size > (off_t)OMAQ_PROXY_FILE_MAX) {
+		close(fd);
+		return -1;
+	}
+	got = read(fd, body, sizeof(body) - 1);
+	close(fd);
+	if (got < 0)
+		return -1;
+	body[got] = '\0';
+	if ((size_t)got != strlen(body))
+		return -1; /* embedded NUL */
+	if (omaq_proxy_parse(body, out) != 0)
+		return -1;
+	return 1;
+}

--- a/helper/proxy.h
+++ b/helper/proxy.h
@@ -1,0 +1,31 @@
+#ifndef OMAQ_PROXY_H
+#define OMAQ_PROXY_H
+
+#include <stddef.h>
+
+#define OMAQ_PROXY_HOST_MAX 256
+#define OMAQ_PROXY_FILE_MAX 4096
+
+enum omaq_proxy_type {
+	OMAQ_PROXY_NONE = 0,
+	OMAQ_PROXY_SOCKS5 = 1,
+	OMAQ_PROXY_HTTP = 2
+};
+
+typedef struct {
+	int type;
+	char host[OMAQ_PROXY_HOST_MAX];
+	unsigned port;
+} omaq_proxy;
+
+/* Parse a whole proxy.conf body: comments (#), blank lines, and exactly one
+ * "<socks5|http|none> <host> <port>" directive ("none" takes no arguments).
+ * 0 = ok, -1 = invalid. */
+int omaq_proxy_parse(const char *text, omaq_proxy *out);
+
+/* Load "$home/proxy.conf". 1 = configured, 0 = absent, -1 = invalid or
+ * unsafe. Callers must fail closed on -1: silently connecting without the
+ * requested proxy would expose the address the user asked to hide. */
+int omaq_proxy_load(const char *home, omaq_proxy *out);
+
+#endif

--- a/helper/relays.c
+++ b/helper/relays.c
@@ -1,0 +1,200 @@
+#define _DEFAULT_SOURCE
+#include "relays.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int host_char_ok(char c)
+{
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+	       (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_' ||
+	       c == ':';
+}
+
+static int host_ok(const char *host, size_t n)
+{
+	size_t i;
+
+	if (n == 0 || n >= OMAQ_RELAY_HOST_MAX)
+		return 0;
+	for (i = 0; i < n; i++) {
+		if (!host_char_ok(host[i]))
+			return 0;
+	}
+	return 1;
+}
+
+static int parse_port(const char *text, size_t n, uint16_t *out)
+{
+	unsigned value = 0;
+	size_t i;
+
+	if (n == 0 || n > 5)
+		return -1;
+	for (i = 0; i < n; i++) {
+		if (text[i] < '0' || text[i] > '9')
+			return -1;
+		value = value * 10u + (unsigned)(text[i] - '0');
+	}
+	if (value == 0 || value > 65535u)
+		return -1;
+	*out = (uint16_t)value;
+	return 0;
+}
+
+static int key_ok(const char *text, size_t n, char *out)
+{
+	size_t i;
+
+	if (n != OMAQ_RELAY_KEY_HEX)
+		return 0;
+	for (i = 0; i < n; i++) {
+		char c = text[i];
+
+		if (c >= 'a' && c <= 'f')
+			c = (char)(c - 'a' + 'A');
+		if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')))
+			return 0;
+		out[i] = c;
+	}
+	out[n] = '\0';
+	return 1;
+}
+
+static size_t token(const char *line, size_t from, size_t length, size_t *end)
+{
+	size_t start = from;
+
+	while (start < length && (line[start] == ' ' || line[start] == '\t'))
+		start++;
+	*end = start;
+	while (*end < length && line[*end] != ' ' && line[*end] != '\t')
+		(*end)++;
+	return start;
+}
+
+static int parse_entry(const char *line, size_t length, omaq_relay *out)
+{
+	omaq_relay parsed;
+	size_t start, end;
+
+	memset(&parsed, 0, sizeof(parsed));
+	start = token(line, 0, length, &end);
+	if (start == end || !host_ok(line + start, end - start))
+		return -1;
+	memcpy(parsed.host, line + start, end - start);
+	parsed.host[end - start] = '\0';
+
+	start = token(line, end, length, &end);
+	if (start == end || parse_port(line + start, end - start, &parsed.udp_port) != 0)
+		return -1;
+
+	start = token(line, end, length, &end);
+	if (start == end || parse_port(line + start, end - start, &parsed.tcp_port) != 0)
+		return -1;
+
+	start = token(line, end, length, &end);
+	if (start == end || !key_ok(line + start, end - start, parsed.key_hex))
+		return -1;
+
+	/* Nothing may follow the key: an unparsed field would mean the file says
+	 * something the helper is not honouring. */
+	start = token(line, end, length, &end);
+	if (start != end)
+		return -1;
+	*out = parsed;
+	return 0;
+}
+
+int omaq_relays_parse(const char *text, omaq_relay_set *out)
+{
+	omaq_relay_set parsed;
+	const char *cursor;
+
+	if (!text || !out)
+		return -1;
+	memset(&parsed, 0, sizeof(parsed));
+	cursor = text;
+	while (*cursor) {
+		const char *newline = strchr(cursor, '\n');
+		size_t length = newline ? (size_t)(newline - cursor) : strlen(cursor);
+		size_t start, end;
+
+		if (length > 0 && cursor[length - 1] == '\r')
+			length--;
+		start = token(cursor, 0, length, &end);
+		if (start != end && cursor[start] != '#') {
+			if (end - start == 9 &&
+			    memcmp(cursor + start, "exclusive", 9) == 0) {
+				size_t next_start, next_end;
+
+				next_start = token(cursor, end, length, &next_end);
+				if (next_start != next_end || parsed.exclusive)
+					return -1;
+				parsed.exclusive = 1;
+			} else {
+				size_t i;
+
+				if (parsed.count >= OMAQ_RELAY_MAX)
+					return -1;
+				if (parse_entry(cursor, length,
+						&parsed.entries[parsed.count]) != 0)
+					return -1;
+				for (i = 0; i < parsed.count; i++) {
+					if (strcmp(parsed.entries[i].key_hex,
+						   parsed.entries[parsed.count].key_hex) == 0)
+						return -1; /* duplicate relay */
+				}
+				parsed.count++;
+			}
+		}
+		if (!newline)
+			break;
+		cursor = newline + 1;
+	}
+	/* "exclusive" with no relay would leave the client with no way to reach
+	 * the network at all; refuse rather than silently going offline. */
+	if (parsed.count == 0)
+		return -1;
+	*out = parsed;
+	return 0;
+}
+
+int omaq_relays_load(const char *home, omaq_relay_set *out)
+{
+	char path[512];
+	char body[OMAQ_RELAY_FILE_MAX + 1];
+	struct stat st;
+	ssize_t got;
+	int fd;
+
+	if (!home || !out)
+		return -1;
+	if (snprintf(path, sizeof(path), "%s/relays.conf", home) >= (int)sizeof(path))
+		return -1;
+	/* Only a genuinely absent file means "use the pinned relays". A symlink
+	 * (ELOOP under O_NOFOLLOW) or any other error fails closed. */
+	fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK);
+	if (fd < 0)
+		return errno == ENOENT ? 0 : -1;
+	if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || st.st_uid != geteuid() ||
+	    st.st_nlink != 1 || (st.st_mode & 0022) ||
+	    st.st_size > (off_t)OMAQ_RELAY_FILE_MAX) {
+		close(fd);
+		return -1;
+	}
+	got = read(fd, body, sizeof(body) - 1);
+	close(fd);
+	if (got < 0)
+		return -1;
+	body[got] = '\0';
+	if ((size_t)got != strlen(body))
+		return -1; /* embedded NUL */
+	if (omaq_relays_parse(body, out) != 0)
+		return -1;
+	return 1;
+}

--- a/helper/relays.h
+++ b/helper/relays.h
@@ -1,0 +1,36 @@
+#ifndef OMAQ_RELAYS_H
+#define OMAQ_RELAYS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define OMAQ_RELAY_HOST_MAX 256
+#define OMAQ_RELAY_KEY_HEX 64
+#define OMAQ_RELAY_MAX 16
+#define OMAQ_RELAY_FILE_MAX 8192
+
+typedef struct {
+	char host[OMAQ_RELAY_HOST_MAX];
+	uint16_t udp_port;
+	uint16_t tcp_port;
+	char key_hex[OMAQ_RELAY_KEY_HEX + 1];
+} omaq_relay;
+
+typedef struct {
+	omaq_relay entries[OMAQ_RELAY_MAX];
+	size_t count;
+	int exclusive; /* 1 = ignore the built-in pinned relays */
+} omaq_relay_set;
+
+/* Parse a whole relays.conf body. Comments (#) and blank lines are ignored.
+ * An optional "exclusive" line on its own means the built-in pinned relays
+ * are not used. Every other line is "<host> <udp-port> <tcp-port> <64-hex
+ * public key>". 0 = ok, -1 = invalid. */
+int omaq_relays_parse(const char *text, omaq_relay_set *out);
+
+/* Load "$home/relays.conf". 1 = configured, 0 = absent, -1 = invalid or
+ * unsafe. Callers must fail closed on -1: quietly ignoring a relay file the
+ * user wrote would send traffic through relays they chose to avoid. */
+int omaq_relays_load(const char *home, omaq_relay_set *out);
+
+#endif

--- a/helper/tox_adapt.c
+++ b/helper/tox_adapt.c
@@ -4,6 +4,7 @@
 #include "tox_adapt.h"
 #include "file.h"
 #include "identity_guard.h"
+#include "proxy.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -123,6 +124,11 @@ struct bootstrap_node {
 	const char *key_hex;
 };
 
+/* Every packet traverses these relays because UDP is disabled, so the set is
+ * deliberately wide and spread across independent operators: no single relay
+ * operator sees all OmaQ traffic, and losing one does not remove
+ * connectivity. Public keys are pinned; hostnames are preferred where the
+ * operator publishes one, because pinned bare addresses decay. */
 static const struct bootstrap_node bootstrap_nodes[] = {
 	{ "144.217.167.73", 33445, 3389,
 	  "7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C" },
@@ -130,6 +136,20 @@ static const struct bootstrap_node bootstrap_nodes[] = {
 	  "B3E5FA80DC8EBD1149AD2AB35ED8B85BD546DEDE261CA593234C619249419506" },
 	{ "139.162.110.188", 33445, 443,
 	  "F76A11284547163889DDC89A7738CF271797BF5E5E220643E97AD3C7E7903D55" },
+	{ "tox.initramfs.io", 33445, 3389,
+	  "3F0A45A268367C1BEA652F258C85F4A66DA76BCAA667A49E770BCC4917AB6A25" },
+	{ "tox.hidemybits.com", 443, 443,
+	  "5D57B95EE4A7F37BA031DAD0CBD9510A9C96FFE09C1CE24A9C33746F39817D6E" },
+	{ "tox2.mf-net.eu", 33445, 3389,
+	  "70EA214FDE161E7432530605213F18F7427DC773E276B3E317A07531F548545F" },
+	{ "172.104.215.182", 33445, 443,
+	  "DA2BD927E01CD05EBCC2574EBE5BEBB10FF59AE0B2105A7D1E2B40E49BB20239" },
+	{ "188.245.84.166", 33445, 443,
+	  "96B66D300BA2B59B98FC42DB1325E7092388F0379593E680ABDBEA03B9C9CE03" },
+	{ "43.198.227.166", 33445, 3389,
+	  "AD13AB0D434BCE6C83FE2649237183964AE3341D0AFB3BE1694B18505E4E135E" },
+	{ "95.181.230.108", 33445, 3389,
+	  "B5FFECB4E4C26409EBB88DB35793E7B39BFA3BA12AC04C096950CB842E3E130A" },
 };
 
 static void bootstrap_tox(struct omaq_tox *t)
@@ -786,6 +806,28 @@ struct omaq_tox *omaq_tox_open(const char *home, const char *pass, int *err_out)
 	tox_options_set_udp_enabled(opt, false);
 	tox_options_set_local_discovery_enabled(opt, false);
 	tox_options_set_hole_punching_enabled(opt, false);
+	{
+		/* Relay operators see the address contacts cannot. An optional
+		 * SOCKS5/HTTP proxy closes that last exposure; a proxy that is
+		 * configured but unusable must never silently fall back to a
+		 * direct connection. */
+		omaq_proxy proxy;
+		int proxy_rc = omaq_proxy_load(home, &proxy);
+
+		if (proxy_rc < 0) {
+			if (err_out)
+				*err_out = OMAQ_TOX_PROXY_INVALID;
+			goto savedata_fail;
+		}
+		if (proxy_rc == 1 && proxy.type != OMAQ_PROXY_NONE) {
+			tox_options_set_proxy_type(
+				opt, proxy.type == OMAQ_PROXY_SOCKS5
+					     ? TOX_PROXY_TYPE_SOCKS5
+					     : TOX_PROXY_TYPE_HTTP);
+			tox_options_set_proxy_host(opt, proxy.host);
+			tox_options_set_proxy_port(opt, (uint16_t)proxy.port);
+		}
+	}
 	save_path(home, path, sizeof(path));
 	save_fd = open(path, O_RDONLY | O_CLOEXEC | O_NONBLOCK | O_NOFOLLOW);
 	if (save_fd < 0 && errno != ENOENT)

--- a/helper/tox_adapt.c
+++ b/helper/tox_adapt.c
@@ -5,6 +5,7 @@
 #include "file.h"
 #include "identity_guard.h"
 #include "proxy.h"
+#include "relays.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -24,6 +25,7 @@
 struct omaq_tox {
 	Tox *tox;
 	ToxAV *av;
+	omaq_relay_set relays;
 	char home[512];
 	char recovery_state[512];
 	int recovery_degraded;
@@ -154,17 +156,42 @@ static const struct bootstrap_node bootstrap_nodes[] = {
 
 static void bootstrap_tox(struct omaq_tox *t)
 {
+	/* User-supplied relays from relays.conf extend the pinned set, or replace
+	 * it entirely when the file says "exclusive". Both lists are walked from
+	 * one registration site so no relay can ever be added on a path that
+	 * skips the retry logic. */
+	size_t pinned = sizeof(bootstrap_nodes) / sizeof(bootstrap_nodes[0]);
+	size_t total;
+
 	if (!t || !t->tox)
 		return;
-	for (size_t i = 0; i < sizeof(bootstrap_nodes) / sizeof(bootstrap_nodes[0]); i++) {
+	if (t->relays.exclusive)
+		pinned = 0;
+	total = pinned + t->relays.count;
+	for (size_t i = 0; i < total; i++) {
+		const char *host;
+		const char *key_hex;
+		uint16_t udp_port, tcp_port;
 		uint8_t key[TOX_PUBLIC_KEY_SIZE];
 		Tox_Err_Bootstrap berr = TOX_ERR_BOOTSTRAP_OK;
-		if (hex_in(bootstrap_nodes[i].key_hex, key, TOX_PUBLIC_KEY_SIZE) != 0)
+
+		if (i < pinned) {
+			host = bootstrap_nodes[i].host;
+			udp_port = bootstrap_nodes[i].udp_port;
+			tcp_port = bootstrap_nodes[i].tcp_port;
+			key_hex = bootstrap_nodes[i].key_hex;
+		} else {
+			const omaq_relay *relay = &t->relays.entries[i - pinned];
+
+			host = relay->host;
+			udp_port = relay->udp_port;
+			tcp_port = relay->tcp_port;
+			key_hex = relay->key_hex;
+		}
+		if (hex_in(key_hex, key, TOX_PUBLIC_KEY_SIZE) != 0)
 			continue;
-		(void)tox_bootstrap(t->tox, bootstrap_nodes[i].host,
-				    bootstrap_nodes[i].udp_port, key, &berr);
-		(void)tox_add_tcp_relay(t->tox, bootstrap_nodes[i].host,
-					bootstrap_nodes[i].tcp_port, key, &berr);
+		(void)tox_bootstrap(t->tox, host, udp_port, key, &berr);
+		(void)tox_add_tcp_relay(t->tox, host, tcp_port, key, &berr);
 	}
 }
 
@@ -819,6 +846,16 @@ struct omaq_tox *omaq_tox_open(const char *home, const char *pass, int *err_out)
 				*err_out = OMAQ_TOX_PROXY_INVALID;
 			goto savedata_fail;
 		}
+		omaq_relay_set relays;
+		int relay_rc = omaq_relays_load(home, &relays);
+
+		if (relay_rc < 0) {
+			if (err_out)
+				*err_out = OMAQ_TOX_RELAYS_INVALID;
+			goto savedata_fail;
+		}
+		if (relay_rc == 1)
+			t->relays = relays;
 		if (proxy_rc == 1 && proxy.type != OMAQ_PROXY_NONE) {
 			tox_options_set_proxy_type(
 				opt, proxy.type == OMAQ_PROXY_SOCKS5

--- a/helper/tox_adapt.h
+++ b/helper/tox_adapt.h
@@ -15,6 +15,7 @@ struct omaq_tox;
 
 #define OMAQ_TOX_LOCKED 1
 #define OMAQ_TOX_PROXY_INVALID 2
+#define OMAQ_TOX_RELAYS_INVALID 3
 
 struct omaq_tox *omaq_tox_open(const char *home, const char *pass, int *err);
 int omaq_tox_protect(struct omaq_tox *t, const char *pass);

--- a/helper/tox_adapt.h
+++ b/helper/tox_adapt.h
@@ -14,6 +14,7 @@ struct omaq_tox;
 #define OMAQ_NICKNAME_MAX_CHARS 18
 
 #define OMAQ_TOX_LOCKED 1
+#define OMAQ_TOX_PROXY_INVALID 2
 
 struct omaq_tox *omaq_tox_open(const char *home, const char *pass, int *err);
 int omaq_tox_protect(struct omaq_tox *t, const char *pass);

--- a/tests/omaq_test.c
+++ b/tests/omaq_test.c
@@ -19,6 +19,7 @@
 #include "../helper/presence.h"
 #include "../helper/proxy.h"
 #include "../helper/receipt.h"
+#include "../helper/relays.h"
 #include "../helper/rate.h"
 #include "../helper/roles.h"
 #include "../helper/safety.h"
@@ -1497,6 +1498,101 @@ static void test_message_rate(void)
 		"g:1000000000000000000000000000000000000000000000000000000000000000",
 		actor, 10000) == 0)
 		fail("message rate global burst limit");
+}
+
+static void test_relays_config(void)
+{
+	omaq_relay_set set;
+	char dir[] = "/tmp/omaq-relays-XXXXXX";
+	char path[512];
+	FILE *f;
+	int i;
+	static const char *valid =
+		"# my own relay\n"
+		"relay.example.internal 33445 443 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n"
+		"  192.0.2.7\t33445 3389 "
+		"b3e5fa80dc8ebd1149ad2ab35ed8b85bd546dede261ca593234c619249419506\n";
+	static const char *invalid[] = {
+		"",
+		"# only a comment\n",
+		"exclusive\n",
+		"relay.example.internal 33445 443\n",
+		"relay.example.internal 33445 443 short\n",
+		"relay.example.internal 0 443 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n",
+		"relay.example.internal 33445 70000 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n",
+		"bad host 33445 443 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n",
+		"relay.example.internal 33445 443 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C extra\n",
+		"exclusive now\n192.0.2.7 33445 443 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n",
+		"192.0.2.7 33445 443 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n"
+		"192.0.2.8 33445 443 "
+		"7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n"
+	};
+
+	memset(&set, 0, sizeof(set));
+	if (omaq_relays_parse(valid, &set) != 0 || set.count != 2 || set.exclusive != 0)
+		fail("relays parse");
+	else if (strcmp(set.entries[0].host, "relay.example.internal") != 0 ||
+		 set.entries[0].udp_port != 33445 || set.entries[0].tcp_port != 443 ||
+		 strcmp(set.entries[1].host, "192.0.2.7") != 0 ||
+		 strcmp(set.entries[1].key_hex,
+			"B3E5FA80DC8EBD1149AD2AB35ED8B85BD546DEDE261CA593234C619249419506") != 0)
+		fail("relays fields");
+	memset(&set, 0, sizeof(set));
+	if (omaq_relays_parse("exclusive\n192.0.2.7 33445 443 "
+			      "7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C\n",
+			      &set) != 0 || set.exclusive != 1 || set.count != 1)
+		fail("relays exclusive");
+	for (i = 0; i < (int)(sizeof(invalid) / sizeof(invalid[0])); i++) {
+		if (omaq_relays_parse(invalid[i], &set) == 0)
+			fail("relays invalid accepted");
+	}
+
+	if (!mkdtemp(dir)) {
+		fail("relays tmpdir");
+		return;
+	}
+	if (omaq_relays_load(dir, &set) != 0)
+		fail("relays absent");
+	snprintf(path, sizeof(path), "%s/relays.conf", dir);
+	f = fopen(path, "w");
+	if (!f) {
+		fail("relays write");
+		return;
+	}
+	fputs(valid, f);
+	fclose(f);
+	if (chmod(path, 0600) != 0)
+		fail("relays chmod");
+	memset(&set, 0, sizeof(set));
+	if (omaq_relays_load(dir, &set) != 1 || set.count != 2)
+		fail("relays load");
+	if (chmod(path, 0666) != 0)
+		fail("relays chmod loose");
+	if (omaq_relays_load(dir, &set) != -1)
+		fail("relays loose accepted");
+	if (chmod(path, 0600) != 0)
+		fail("relays chmod back");
+	f = fopen(path, "w");
+	if (!f) {
+		fail("relays rewrite");
+		return;
+	}
+	fputs("192.0.2.7 33445 443 nope\n", f);
+	fclose(f);
+	if (omaq_relays_load(dir, &set) != -1)
+		fail("relays malformed accepted");
+	unlink(path);
+	if (symlink("/etc/hostname", path) == 0 && omaq_relays_load(dir, &set) != -1)
+		fail("relays symlink accepted");
+	unlink(path);
+	rmdir(dir);
 }
 
 static void test_proxy_config(void)
@@ -3375,6 +3471,7 @@ int main(void)
 	test_message_rate();
 	test_safety();
 	test_proxy_config();
+	test_relays_config();
 	test_group_file_wire();
 	test_group_invite();
 	test_direct_state();

--- a/tests/omaq_test.c
+++ b/tests/omaq_test.c
@@ -17,6 +17,7 @@
 #include "../helper/ratchet.h"
 #include "../helper/ratchet_pin.h"
 #include "../helper/presence.h"
+#include "../helper/proxy.h"
 #include "../helper/receipt.h"
 #include "../helper/rate.h"
 #include "../helper/roles.h"
@@ -1496,6 +1497,97 @@ static void test_message_rate(void)
 		"g:1000000000000000000000000000000000000000000000000000000000000000",
 		actor, 10000) == 0)
 		fail("message rate global burst limit");
+}
+
+static void test_proxy_config(void)
+{
+	omaq_proxy proxy;
+	char dir[] = "/tmp/omaq-proxy-XXXXXX";
+	char path[512];
+	FILE *f;
+	int i;
+	static const char *invalid[] = {
+		"",
+		"\n\n# only comments\n",
+		"socks5 127.0.0.1\n",
+		"socks5 127.0.0.1 9050 extra\n",
+		"socks5 127.0.0.1 0\n",
+		"socks5 127.0.0.1 65536\n",
+		"socks5 127.0.0.1 -1\n",
+		"socks5  9050\n",
+		"socks4 127.0.0.1 9050\n",
+		"socks5 bad host 9050\n",
+		"socks5 host;rm 9050\n",
+		"none 127.0.0.1\n",
+		"socks5 127.0.0.1 9050\nhttp 127.0.0.1 8080\n"
+	};
+
+	memset(&proxy, 0, sizeof(proxy));
+	if (omaq_proxy_parse("socks5 127.0.0.1 9050\n", &proxy) != 0 ||
+	    proxy.type != OMAQ_PROXY_SOCKS5 || strcmp(proxy.host, "127.0.0.1") != 0 ||
+	    proxy.port != 9050)
+		fail("proxy socks5");
+	memset(&proxy, 0, sizeof(proxy));
+	if (omaq_proxy_parse("# tor\n\n  http\tproxy.example.internal  8080  \n", &proxy) != 0 ||
+	    proxy.type != OMAQ_PROXY_HTTP ||
+	    strcmp(proxy.host, "proxy.example.internal") != 0 || proxy.port != 8080)
+		fail("proxy http");
+	memset(&proxy, 0, sizeof(proxy));
+	if (omaq_proxy_parse("none\n", &proxy) != 0 || proxy.type != OMAQ_PROXY_NONE)
+		fail("proxy none");
+	memset(&proxy, 0, sizeof(proxy));
+	if (omaq_proxy_parse("socks5 ::1 9050\n", &proxy) != 0 ||
+	    strcmp(proxy.host, "::1") != 0)
+		fail("proxy ipv6");
+	for (i = 0; i < (int)(sizeof(invalid) / sizeof(invalid[0])); i++) {
+		if (omaq_proxy_parse(invalid[i], &proxy) == 0)
+			fail("proxy invalid accepted");
+	}
+
+	if (!mkdtemp(dir)) {
+		fail("proxy tmpdir");
+		return;
+	}
+	/* Absent file means no proxy. */
+	if (omaq_proxy_load(dir, &proxy) != 0)
+		fail("proxy absent");
+	snprintf(path, sizeof(path), "%s/proxy.conf", dir);
+	f = fopen(path, "w");
+	if (!f) {
+		fail("proxy write");
+		return;
+	}
+	fputs("socks5 127.0.0.1 9050\n", f);
+	fclose(f);
+	if (chmod(path, 0600) != 0)
+		fail("proxy chmod");
+	memset(&proxy, 0, sizeof(proxy));
+	if (omaq_proxy_load(dir, &proxy) != 1 || proxy.type != OMAQ_PROXY_SOCKS5 ||
+	    proxy.port != 9050)
+		fail("proxy load");
+	/* A world-writable config is refused, not silently ignored. */
+	if (chmod(path, 0666) != 0)
+		fail("proxy chmod loose");
+	if (omaq_proxy_load(dir, &proxy) != -1)
+		fail("proxy loose accepted");
+	if (chmod(path, 0600) != 0)
+		fail("proxy chmod back");
+	/* A malformed config fails closed instead of connecting directly. */
+	f = fopen(path, "w");
+	if (!f) {
+		fail("proxy rewrite");
+		return;
+	}
+	fputs("socks5 127.0.0.1\n", f);
+	fclose(f);
+	if (omaq_proxy_load(dir, &proxy) != -1)
+		fail("proxy malformed accepted");
+	/* A symlinked config is refused. */
+	unlink(path);
+	if (symlink("/etc/hostname", path) == 0 && omaq_proxy_load(dir, &proxy) != -1)
+		fail("proxy symlink accepted");
+	unlink(path);
+	rmdir(dir);
 }
 
 static void test_safety(void)
@@ -3282,6 +3374,7 @@ int main(void)
 	test_group_file_offer_rate();
 	test_message_rate();
 	test_safety();
+	test_proxy_config();
 	test_group_file_wire();
 	test_group_invite();
 	test_direct_state();

--- a/tests/qml_plaintext_test.py
+++ b/tests/qml_plaintext_test.py
@@ -19,7 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 QML_POLICY_SHA256 = {
     "CallTone.qml": "12d873ec1b774ed038fb526b0b2b7fd2a1a71e97d9987aa27fef06f6f4d93ddc",
     "ChatSurface.qml": "85c63d92d66aebc53556d178276ab0aa31bb20556548dd3a7727ab4fda320d3f",
-    "Panel.qml": "cc888b37da8de0afc955ed04f0aab40577670edf574fac7ba4d8ba771d6b5d77",
+    "Panel.qml": "e5257a99a765ee8756864a772634f9bb851a0a1999d355a1a89875a47720febd",
     "PlacementController.qml": "82f72fcee9a6aceeb6d1015095fea4961eb2cddbdc11943ef410e160060df76a",
     "SafeText.qml": "a8bfa2ea5e13cbd50bf7e9c70995bea06ceeaca9c9d61e63b243ce18a830e354",
     "Service.qml": "ffd4171eb4506e6722fcb0747cf99bbf3c4fc341a9877fb20a5c3c1ab7ddf5ec",
@@ -146,7 +146,7 @@ REVIEWED_COMPUTED_IDS = set().union(*COMPUTED_WRITE_ALLOWLIST.values())
 COMPUTED_WRITE_SOURCE_SHA256 = {
     "CallTone.qml": "8d9a0af95e58b888dfd09e37c198684843aa10d306f815abc868b88c61496c86",
     "ChatSurface.qml": "61cb0a3d9aecdecdac9bc1ad1cefa941dd4f3047a0c2bfe336484eded210661d",
-    "Panel.qml": "0bb106d37a920d1cf34d316fc9e08610c868f9d8f4e9863128075eaa27c8fcbc",
+    "Panel.qml": "be2559aaf5b63c675b239b4a9d010f5c0e3ae7d0d6cf77674c83565ea6a21c8b",
     "Service.qml": "2395f4a77de4bc06a4cd21ad77bdd19fe98c9d41b2bd48de7bfb69eb1d383809",
     "pages/ChatPage.qml": "3232198c177017757631b97f59c5f45f7442cd9ca58b3c3972dec81e72c8a076",
 }

--- a/tests/tcp_relay_retry_source_test.py
+++ b/tests/tcp_relay_retry_source_test.py
@@ -66,6 +66,17 @@ if sum(1 for host in hosts if not re.fullmatch(r"[0-9.]+", host)) < 3:
 
 # A configured proxy must be applied, and an unusable one must fail closed
 # rather than silently connecting directly.
+# User-supplied relays must extend or replace the pinned set through the same
+# single registration site, and an unusable relay file must fail closed.
+if "omaq_relays_load(home, &relays)" not in open_body:
+    raise SystemExit("tcp-relay-retry-source: relays.conf is not consulted")
+if "OMAQ_TOX_RELAYS_INVALID" not in open_body:
+    raise SystemExit("tcp-relay-retry-source: relay config failure is not fail-closed")
+if "t->relays" not in bootstrap:
+    raise SystemExit("tcp-relay-retry-source: user relays are not registered")
+if "t->relays.exclusive" not in bootstrap:
+    raise SystemExit("tcp-relay-retry-source: exclusive relay mode is not honoured")
+
 for needle in (
     "omaq_proxy_load(home, &proxy)",
     "tox_options_set_proxy_type(",
@@ -80,5 +91,5 @@ if open_body.index("omaq_proxy_load(home, &proxy)") > open_body.index("tox_new(o
 
 print(
     "tcp-relay-retry-source: ok startup=relays periodic=relays udp=false "
-    "relays=%d proxy=optional" % len(entries)
+    "relays=%d proxy=optional user-relays=optional" % len(entries)
 )

--- a/tests/tcp_relay_retry_source_test.py
+++ b/tests/tcp_relay_retry_source_test.py
@@ -43,4 +43,42 @@ if iterate.count("bootstrap_tox(t);") != 1:
 if "tox_options_set_udp_enabled(opt, false);" not in open_body:
     raise SystemExit("tcp-relay-retry-source: TCP-only privacy mode changed")
 
-print("tcp-relay-retry-source: ok startup=relays periodic=relays udp=false")
+# Every packet crosses the relay set, so it must stay wide and key-pinned.
+table = re.search(
+    r"static const struct bootstrap_node bootstrap_nodes\[\]\s*=\s*\{(.*?)\n\};",
+    SOURCE,
+    re.S,
+)
+if not table:
+    raise SystemExit("tcp-relay-retry-source: bootstrap node table missing")
+entries = re.findall(r'\{\s*"([^"]+)",\s*(\d+),\s*(\d+),\s*"([0-9A-F]{64})"',
+                     table.group(1))
+if len(entries) < 8:
+    raise SystemExit(
+        "tcp-relay-retry-source: relay set narrowed to %d nodes" % len(entries)
+    )
+hosts = [entry[0] for entry in entries]
+keys = [entry[3] for entry in entries]
+if len(set(hosts)) != len(hosts) or len(set(keys)) != len(keys):
+    raise SystemExit("tcp-relay-retry-source: duplicate relay entry")
+if sum(1 for host in hosts if not re.fullmatch(r"[0-9.]+", host)) < 3:
+    raise SystemExit("tcp-relay-retry-source: too few relays reached by hostname")
+
+# A configured proxy must be applied, and an unusable one must fail closed
+# rather than silently connecting directly.
+for needle in (
+    "omaq_proxy_load(home, &proxy)",
+    "tox_options_set_proxy_type(",
+    "tox_options_set_proxy_host(opt, proxy.host)",
+    "tox_options_set_proxy_port(",
+    "OMAQ_TOX_PROXY_INVALID",
+):
+    if needle not in open_body:
+        raise SystemExit("tcp-relay-retry-source: missing proxy support: %s" % needle)
+if open_body.index("omaq_proxy_load(home, &proxy)") > open_body.index("tox_new(opt"):
+    raise SystemExit("tcp-relay-retry-source: proxy applied after tox_new")
+
+print(
+    "tcp-relay-retry-source: ok startup=relays periodic=relays udp=false "
+    "relays=%d proxy=optional" % len(entries)
+)

--- a/tests/tox_relay_retry_test.c
+++ b/tests/tox_relay_retry_test.c
@@ -94,10 +94,24 @@ static void reset_counts(void)
 	tuple_errors = 0;
 }
 
+#define OMAQ_RELAY_NODE_COUNT \
+	(sizeof(bootstrap_nodes) / sizeof(bootstrap_nodes[0]))
+#define OMAQ_RELAY_FULL_MASK ((1u << OMAQ_RELAY_NODE_COUNT) - 1u)
+
 static void require_stage(const char *stage)
 {
-	if (bootstrap_calls != 3 || relay_calls != 3 ||
-	    bootstrap_mask != 0x7 || relay_mask != 0x7 || tuple_errors != 0) {
+	/* Every pinned node must be contacted on every attempt, and the set must
+	 * stay wide: a narrow relay set concentrates all metadata on a few
+	 * operators and makes a single outage fatal. */
+	if (OMAQ_RELAY_NODE_COUNT < 8) {
+		fprintf(stderr, "tox-relay-retry: relay set narrowed to %u nodes\n",
+			(unsigned)OMAQ_RELAY_NODE_COUNT);
+		exit(1);
+	}
+	if (bootstrap_calls != (unsigned)OMAQ_RELAY_NODE_COUNT ||
+	    relay_calls != (unsigned)OMAQ_RELAY_NODE_COUNT ||
+	    bootstrap_mask != OMAQ_RELAY_FULL_MASK ||
+	    relay_mask != OMAQ_RELAY_FULL_MASK || tuple_errors != 0) {
 		fprintf(stderr,
 			"tox-relay-retry: %s bootstrap=%u relay=%u "
 			"bootstrap_mask=0x%x relay_mask=0x%x tuple_errors=%u\n",
@@ -157,6 +171,9 @@ int main(void)
 		perror("tox-relay-retry: cleanup");
 		return 1;
 	}
-	puts("tox-relay-retry: ok startup=3/3 offline=3/3 online=3/3");
+	printf("tox-relay-retry: ok startup=%u/%u offline=%u/%u online=%u/%u\n",
+	       (unsigned)OMAQ_RELAY_NODE_COUNT, (unsigned)OMAQ_RELAY_NODE_COUNT,
+	       (unsigned)OMAQ_RELAY_NODE_COUNT, (unsigned)OMAQ_RELAY_NODE_COUNT,
+	       (unsigned)OMAQ_RELAY_NODE_COUNT, (unsigned)OMAQ_RELAY_NODE_COUNT);
 	return 0;
 }

--- a/tests/tox_relay_retry_test.c
+++ b/tests/tox_relay_retry_test.c
@@ -13,7 +13,7 @@ static char temporary_home[] = "/tmp/omaq-relay-retry-XXXXXX";
 static int remove_home(void)
 {
 	char path[sizeof(temporary_home) + 16];
-	const char *names[] = { "tox.save", "tox.save.tmp" };
+	const char *names[] = { "tox.save", "tox.save.tmp", "relays.conf" };
 
 	if (!temporary_home[0])
 		return 0;
@@ -167,6 +167,69 @@ int main(void)
 	}
 
 	omaq_tox_close(tox);
+
+	/* A user-supplied relay must be registered alongside the pinned set,
+	 * through the same retry path. */
+	{
+		char path[sizeof(temporary_home) + 32];
+		FILE *config;
+
+		snprintf(path, sizeof(path), "%s/relays.conf", temporary_home);
+		config = fopen(path, "w");
+		if (!config) {
+			perror("tox-relay-retry: relays.conf");
+			return 1;
+		}
+		fputs("192.0.2.55 33445 443 "
+		      "0000000000000000000000000000000000000000000000000000000000000001\n",
+		      config);
+		if (fclose(config) != 0 || chmod(path, 0600) != 0) {
+			fprintf(stderr, "tox-relay-retry: relays.conf write failed\n");
+			return 1;
+		}
+		reset_counts();
+		tox = omaq_tox_open(temporary_home, NULL, &error);
+		if (!tox) {
+			fprintf(stderr, "tox-relay-retry: user relay open failed: %d\n",
+				error);
+			return 1;
+		}
+		if (bootstrap_calls != (unsigned)OMAQ_RELAY_NODE_COUNT + 1u ||
+		    relay_calls != (unsigned)OMAQ_RELAY_NODE_COUNT + 1u ||
+		    bootstrap_mask != OMAQ_RELAY_FULL_MASK ||
+		    relay_mask != OMAQ_RELAY_FULL_MASK || tuple_errors != 2) {
+			fprintf(stderr,
+				"tox-relay-retry: user relay bootstrap=%u relay=%u "
+				"tuple_errors=%u\n",
+				bootstrap_calls, relay_calls, tuple_errors);
+			omaq_tox_close(tox);
+			return 1;
+		}
+		omaq_tox_close(tox);
+
+		/* A malformed relay file must fail closed, not fall back. */
+		config = fopen(path, "w");
+		if (!config) {
+			perror("tox-relay-retry: relays.conf rewrite");
+			return 1;
+		}
+		fputs("192.0.2.55 33445 443 nope\n", config);
+		if (fclose(config) != 0 || chmod(path, 0600) != 0) {
+			fprintf(stderr, "tox-relay-retry: relays.conf rewrite failed\n");
+			return 1;
+		}
+		error = 0;
+		tox = omaq_tox_open(temporary_home, NULL, &error);
+		if (tox || error != OMAQ_TOX_RELAYS_INVALID) {
+			fprintf(stderr,
+				"tox-relay-retry: malformed relays.conf accepted (%d)\n",
+				error);
+			if (tox)
+				omaq_tox_close(tox);
+			return 1;
+		}
+	}
+
 	if (remove_home() != 0) {
 		perror("tox-relay-retry: cleanup");
 		return 1;


### PR DESCRIPTION
Closes #40.

## What this does

Three changes, all fail-closed, addressing the three clauses of the issue.

### 1. Wider, more diverse pinned relay set (3 → 10)

`helper/tox_adapt.c` now pins **10** nodes across **9 independent operators**, 4 of them reached by hostname rather than a bare IP. Selected from the live `nodes.tox.chat` list with `status_tcp` confirmed at the time of writing; TCP port chosen per node preferring 443, then 3389. Key pinning is unchanged — every node still carries its full public key.

Rationale is in a comment at the table: because UDP is disabled, every packet crosses a relay, so no single operator should see all OmaQ traffic and losing one must not remove connectivity.

### 2. Optional SOCKS5 / HTTP proxy

New **`helper/proxy.c`** reads an optional `~/.local/share/omaq/proxy.conf`:

```
socks5 127.0.0.1 9050
```

`http <host> <port>` and `none` are also accepted; `#` comments and blank lines are ignored. It is wired to `tox_options_set_proxy_type/host/port` before `tox_new`, so a Tor user can finally close the last IP-exposure gap.

### 3. User-supplied relays

New **`helper/relays.c`** reads an optional `relays.conf` with up to 16 entries:

```
# your own tox-bootstrapd
relay.example.org 33445 443 7E5668E0EE09E19F320AD47902419331FFEE147BB3606769CFBE921A2A2FD34C
```

These extend the pinned set. A line containing only `exclusive` uses **only** the listed relays, removing the public operators from the path entirely. Public keys are required and pinned exactly as the built-in ones are.

Both lists are walked from a **single registration site** inside `bootstrap_tox()`, so no relay can ever be added on a path that skips the existing periodic retry logic — which is what `tests/tcp_relay_retry_source_test.py` already guards.

## Fail-closed behaviour

A `proxy.conf` or `relays.conf` that exists but is malformed, unreadable, a symlink (`O_NOFOLLOW` → `ELOOP`), group/other-writable, oversized, or contains an embedded NUL **stops the helper** with `proxy_invalid` / `relays_invalid` rather than connecting the way the user was trying to prevent. Only a genuinely absent file (`ENOENT`) means "no proxy" / "use the pinned relays". `exclusive` with no relay listed is refused rather than silently going offline. Both codes get explicit, actionable messages in the panel instead of a raw code.

## Tests

- `tests/omaq_test.c` — parser suites for both files under ASAN/UBSAN: **24 invalid inputs rejected** (missing/extra fields, port 0, port 65536, negative port, bad host characters, unknown scheme, short key, duplicate relay, `exclusive` with arguments, two directives, comment-only, empty), plus the load path: absent → 0, valid → 1, group-writable → −1, malformed → −1, symlinked → −1.
- `tests/tox_relay_retry_test.c` — now derives the expected count from the table instead of hardcoding 3, asserts **every** pinned and user relay is registered on startup and on both periodic retries, requires the set to stay ≥ 8 nodes, and asserts a malformed `relays.conf` returns `OMAQ_TOX_RELAYS_INVALID` instead of falling back.
- `tests/tcp_relay_retry_source_test.py` — extended to enforce ≥ 8 relays, ≥ 3 hostnames, no duplicate hosts or keys, the proxy applied before `tox_new`, and the user-relay path going through the same single registration site.

## Docs

`docs/SECURITY.md` gains the `proxy.conf` and `relays.conf` recipes, states that the relay set is spread across independent operators, and is explicit that the address hidden from contacts is still visible to relay operators unless a proxy is configured.

## Verification

`make test` passes end-to-end (exit 0) on this branch, on Omarchy/Arch Linux ARM (aarch64). `tox-relay-retry: ok startup=10/10 offline=10/10 online=10/10`. Rebased onto current `main` (`4c69438`); reviewed originally at `3cf3751`.

> Note: #39 and #41 touch some of the same files. Each branch is cut independently from `main`; happy to rebase this one behind #42 in whatever order you prefer to merge.

