### PR TITLE
security: seal chat history and Ratchet state at rest under the identity passphrase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ TOX_OK := $(shell $(PKG_CONFIG) --exists libtoxcore && echo yes || \
 SIG_OK := $(shell $(PKG_CONFIG) --exists libsignal-protocol-c && echo yes || echo no)
 PULSE_OK := $(shell $(PKG_CONFIG) --exists libpulse && echo yes || echo no)
 IMAGE_OK := $(shell $(PKG_CONFIG) --exists libpng libjpeg libwebp && echo yes || echo no)
+SODIUM_OK := $(shell $(PKG_CONFIG) --exists libsodium && echo yes || echo no)
+SODIUM_CFLAGS := $(shell $(PKG_CONFIG) --cflags libsodium 2>/dev/null)
+SODIUM_LIBS := $(shell $(PKG_CONFIG) --libs libsodium 2>/dev/null)
+CFLAGS += $(SODIUM_CFLAGS)
 
 ifeq ($(TOX_OK),yes)
   TOX_PC := $(shell $(PKG_CONFIG) --exists libtoxcore && echo libtoxcore || echo toxcore)
@@ -43,7 +47,7 @@ endif
 LIB_SRC := helper/invite.c helper/roles.c helper/conversation.c helper/auto_open.c \
 	helper/group_file.c helper/group_file_store.c helper/json_io.c helper/text.c helper/line_reader.c helper/stdout_spool.c helper/state_archive.c helper/store.c helper/message.c \
 	helper/identity.c helper/identity_guard.c helper/tox_adapt.c helper/rate.c \
-	helper/safety.c helper/qr.c helper/group.c helper/group_invite.c \
+	helper/safety.c helper/seal.c helper/qr.c helper/group.c helper/group_invite.c \
 	helper/surface.c helper/sound.c helper/file.c helper/avatar.c helper/av.c \
 	helper/presence.c helper/receipt.c helper/message_action.c helper/direct_state.c \
 	helper/ratchet.c helper/ratchet_pin.c helper/ratchet_adapt.c
@@ -51,7 +55,7 @@ HELPER_SRC := $(LIB_SRC) helper/omaq.c
 TEST_SRC := tests/omaq_test.c helper/invite.c helper/roles.c helper/conversation.c helper/auto_open.c \
 	helper/group_file.c helper/group_file_store.c helper/json_io.c helper/text.c helper/line_reader.c helper/store.c helper/message.c helper/identity.c \
 	helper/identity_guard.c \
-	helper/rate.c helper/safety.c helper/qr.c helper/group.c helper/group_invite.c \
+	helper/rate.c helper/safety.c helper/seal.c helper/qr.c helper/group.c helper/group_invite.c \
 	helper/surface.c helper/sound.c helper/state_archive.c helper/file.c helper/avatar.c helper/presence.c helper/receipt.c helper/message_action.c \
 	helper/direct_state.c helper/ratchet.c helper/ratchet_pin.c
 
@@ -85,13 +89,13 @@ else
   REINVITE_TEST_COMMAND := @echo "reinvite-recovery: skipped (full helper dependencies unavailable)"
 endif
 
-.PHONY: all test helper check-signal check-audio check-images arch verify verify-0 verify-1 verify-1-offline verify-1-tox \
+.PHONY: all test helper check-signal check-audio check-images check-sodium arch verify verify-0 verify-1 verify-1-offline verify-1-tox \
 	verify-2 verify-3 verify-4 verify-5 verify-6 verify-7 verify-8 clean
 
 all: $(BIN_TEST) helper
 
 $(BIN_TEST): $(TEST_SRC)
-	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) $(AVATAR_CFLAGS) -o $@ $(TEST_SRC) $(AVATAR_LIBS)
+	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) $(AVATAR_CFLAGS) $(SODIUM_CFLAGS) -o $@ $(TEST_SRC) $(AVATAR_LIBS) $(SODIUM_LIBS)
 
 $(BIN_SPOOL_TEST): tests/stdout_spool_test.c helper/stdout_spool.c helper/stdout_spool.h
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DOMAQ_STDOUT_SPOOL_MAX=5242880u \
@@ -127,12 +131,12 @@ $(BIN_TOX_RELAY_RETRY_TEST): tests/tox_relay_retry_test.c helper/tox_adapt.c hel
 
 $(BIN_IPC_TEST_HELPER): $(HELPER_SRC)
 	$(CC) -std=c11 -Wall -Werror -Wno-unused-function -O1 $(SANFLAGS) -DOMAQ_IPC_TEST \
-		-DOMAQ_STDOUT_SPOOL_MAX=5242880u $(AVATAR_CFLAGS) -o $@ $(HELPER_SRC) \
-		$(AVATAR_LIBS)
+		-DOMAQ_STDOUT_SPOOL_MAX=5242880u $(AVATAR_CFLAGS) $(SODIUM_CFLAGS) -o $@ $(HELPER_SRC) \
+		$(AVATAR_LIBS) $(SODIUM_LIBS)
 
-$(BIN_GROUP_ADMIN_TEST_HELPER): check-signal $(HELPER_SRC)
+$(BIN_GROUP_ADMIN_TEST_HELPER): check-signal check-sodium $(HELPER_SRC)
 	$(CC) $(CFLAGS) $(HARDEN_CFLAGS) $(HARDEN_LDFLAGS) \
-		-DOMAQ_IPC_TEST -DOMAQ_TOX_TEST -o $@ $(HELPER_SRC) $(TOX_LIBS)
+		-DOMAQ_IPC_TEST -DOMAQ_TOX_TEST -o $@ $(HELPER_SRC) $(TOX_LIBS) $(SODIUM_LIBS)
 
 check-signal:
 	@if [ "$(SIG_OK)" != "yes" ]; then \
@@ -148,14 +152,21 @@ check-audio:
 		exit 1; \
 	fi
 
+check-sodium:
+	@if [ "$(SODIUM_OK)" != "yes" ]; then \
+		echo "omaq: libsodium is required to encrypt local history and Ratchet state" >&2; \
+		echo "omaq: install libsodium before running 'make helper'" >&2; \
+		exit 1; \
+	fi
+
 check-images:
 	@if [ "$(IMAGE_OK)" != "yes" ]; then \
 		echo "omaq: libpng, libjpeg and libwebp are required for safe avatar decoding" >&2; \
 		exit 1; \
 	fi
 
-$(BIN_HELP): check-signal check-audio check-images $(HELPER_SRC)
-	$(CC) $(CFLAGS) $(HARDEN_CFLAGS) $(HARDEN_LDFLAGS) -o $@ $(HELPER_SRC) $(TOX_LIBS)
+$(BIN_HELP): check-signal check-audio check-images check-sodium $(HELPER_SRC)
+	$(CC) $(CFLAGS) $(HARDEN_CFLAGS) $(HARDEN_LDFLAGS) -o $@ $(HELPER_SRC) $(TOX_LIBS) $(SODIUM_LIBS)
 
 test: $(BIN_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TEST) $(SIGNAL_TEST_TARGET) $(IDENTITY_GUARD_TEST_TARGET) $(TOX_RELAY_RETRY_TEST_TARGET) $(BIN_IPC_TEST_HELPER) $(REINVITE_TEST_TARGET)
 	./$(BIN_TEST)
@@ -223,6 +234,7 @@ verify-0: test arch
 verify-1-offline: test arch helper
 	sh tests/lock-elect.sh
 	sh tests/two-clients.sh
+	sh tests/history-seal.sh
 	omarchy plugin validate .
 	@echo "verify-1-offline: ok"
 
@@ -245,6 +257,7 @@ verify-2: test arch helper
 	fi
 	sh tests/lock-elect.sh
 	sh tests/two-clients.sh
+	sh tests/history-seal.sh
 	omarchy plugin validate .
 	sh tests/phase2.sh
 	@echo "verify-2: ok"

--- a/Makefile
+++ b/Makefile
@@ -109,11 +109,11 @@ $(BIN_AV_STATE_TEST): tests/av_state_test.c helper/av.c helper/av.h helper/tox_a
 	$(CC) -std=c11 -Wall -Werror -Wno-unused-function -O1 $(SANFLAGS) -DHAVE_TOX -o $@ \
 		tests/av_state_test.c helper/av.c -pthread
 
-$(BIN_RATCHET_PREKEY_TEST): tests/ratchet_prekey_test.c helper/ratchet.c helper/ratchet_adapt.c helper/ratchet.h
+$(BIN_RATCHET_PREKEY_TEST): tests/ratchet_prekey_test.c helper/ratchet.c helper/ratchet_adapt.c helper/seal.c helper/ratchet.h
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DHAVE_SIGNAL \
-		$(shell $(PKG_CONFIG) --cflags libsignal-protocol-c) -o $@ \
-		tests/ratchet_prekey_test.c helper/ratchet.c helper/ratchet_adapt.c \
-		$(shell $(PKG_CONFIG) --libs libsignal-protocol-c libcrypto)
+		$(shell $(PKG_CONFIG) --cflags libsignal-protocol-c) $(SODIUM_CFLAGS) -o $@ \
+		tests/ratchet_prekey_test.c helper/ratchet.c helper/ratchet_adapt.c helper/seal.c \
+		$(shell $(PKG_CONFIG) --libs libsignal-protocol-c libcrypto) $(SODIUM_LIBS)
 
 $(BIN_IDENTITY_GUARD_TEST): tests/identity_guard_test.c helper/identity_guard.c helper/tox_adapt.c helper/file.c
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DHAVE_TOX -DOMAQ_TOX_TEST \

--- a/Panel.qml
+++ b/Panel.qml
@@ -5076,7 +5076,7 @@ BarWidget {
               SafeText {
                 visible: root.moreSection === "identity"
                 width: parent.width
-                text: "The passphrase encrypts the identity file and your chat history. Ratchet state and keys, avatars, receipts, and preferences stay unencrypted on disk under your account, so a copy of this disk or a backup still reveals who you talk to. Protect the device itself with full-disk encryption."
+                text: "The passphrase encrypts the identity file, your chat history, and your encryption keys. Avatars, received files, receipts, and preferences stay unencrypted on disk under your account, so a copy of this disk or a backup still reveals some metadata. Protect the device itself with full-disk encryption."
                 color: root.systemColors[1] || root.dim
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption

--- a/Panel.qml
+++ b/Panel.qml
@@ -4358,6 +4358,15 @@ BarWidget {
                 font.pixelSize: Style.font.caption
               }
 
+              SafeText {
+                width: parent.width
+                text: "Anyone who sees this link or QR before your contact does can redeem it and become that contact. Send it through a channel only they can read, and revoke it if it may have leaked."
+                color: root.urgent
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.WordWrap
+              }
+
               Column {
                 id: inviteSteps
                 visible: root.inviteConfirmMode === ""
@@ -5059,6 +5068,16 @@ BarWidget {
                 width: parent.width
                 text: "Use at least 8 characters and at most 128 bytes."
                 color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.WordWrap
+              }
+
+              SafeText {
+                visible: root.moreSection === "identity"
+                width: parent.width
+                text: "The passphrase encrypts the identity file and your chat history. Ratchet state and keys, avatars, receipts, and preferences stay unencrypted on disk under your account, so a copy of this disk or a backup still reveals who you talk to. Protect the device itself with full-disk encryption."
+                color: root.systemColors[1] || root.dim
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption
                 wrapMode: Text.WordWrap

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Tox encrypts transport end to end, and direct text messages add the Signal Double Ratchet. OmaQ disables direct UDP discovery and hole punching, so contacts do not receive each other's IP addresses.
 
-OmaQ runs no servers and has no operator access to your identity, contacts, or messages. Public Tox bootstrap and relay nodes can forward encrypted packets but cannot read message contents. Setting the optional passphrase encrypts both `tox.save` and your chat history at rest (Argon2id + XChaCha20-Poly1305); Ratchet state, avatars, receipts, and preferences are still protected only by local filesystem permissions.
+OmaQ runs no servers and has no operator access to your identity, contacts, or messages. Public Tox bootstrap and relay nodes can forward encrypted packets but cannot read message contents. Setting the optional passphrase encrypts `tox.save`, your chat history, and your Ratchet state — including the Signal identity private key — at rest (Argon2id + XChaCha20-Poly1305); avatars, receipts, and preferences are still protected only by local filesystem permissions.
 
 Use OmaQ only for lawful private communication with people you trust.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Tox encrypts transport end to end, and direct text messages add the Signal Double Ratchet. OmaQ disables direct UDP discovery and hole punching, so contacts do not receive each other's IP addresses.
 
-OmaQ runs no servers and has no operator access to your identity, contacts, or messages. Public Tox bootstrap and relay nodes can forward encrypted packets but cannot read message contents. Local filesystem permissions protect Ratchet state, avatars, receipts, preferences, and chat history that are not covered by the optional `tox.save` passphrase.
+OmaQ runs no servers and has no operator access to your identity, contacts, or messages. Public Tox bootstrap and relay nodes can forward encrypted packets but cannot read message contents. Setting the optional passphrase encrypts both `tox.save` and your chat history at rest (Argon2id + XChaCha20-Poly1305); Ratchet state, avatars, receipts, and preferences are still protected only by local filesystem permissions.
 
 Use OmaQ only for lawful private communication with people you trust.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -42,9 +42,11 @@ Source updates build an externally staged Git checkout before stopping the shell
 
 ## Know the passphrase boundary
 
-A passphrase encrypts the Tox savedata in `tox.save` **and your chat history**. Setting a passphrase derives a second key with Argon2id, stores it wrapped in `~/.local/share/omaq/seal.key`, and rewrites every stored transcript so each message record is sealed with XChaCha20-Poly1305. Removing the passphrase reverses the migration and deletes the key. Without the passphrase, sealed transcripts are unreadable: they are never shown as plaintext and never silently reported as empty.
+A passphrase encrypts the Tox savedata in `tox.save`, **your chat history, and your Ratchet state** — including the Signal identity private key. Setting a passphrase derives a second key with Argon2id, stores it wrapped in `~/.local/share/omaq/seal.key`, and rewrites every stored transcript and Ratchet blob so each one is sealed with XChaCha20-Poly1305. Removing the passphrase reverses the migration and deletes the key. Without the passphrase, sealed data is unreadable: it is never shown as plaintext and never silently reported as empty.
 
-It still does not encrypt Ratchet state, avatars, receipts, or preferences. In particular the Signal Ratchet identity private key under `~/.local/share/omaq/ratchet/` remains plaintext, because its lifetime is tied to identity replacement and recovery flows that must be reworked before it can be sealed safely; a disk image or backup therefore still reveals contact and session metadata. Use full-disk encryption when that matters.
+If a home ends up holding Ratchet state sealed under a passphrase the current identity no longer carries — for example an identity restored from a recovery copy that predates the passphrase — OmaQ moves that store aside to `ratchet.locked-<time>-<token>` and requires fresh invitations rather than opening a partly unreadable store. Nothing is deleted: the sealed bytes remain recoverable if the passphrase turns up.
+
+Avatars, received files, receipts, preferences, and unread state are still covered only by local filesystem permissions, so a disk image or backup still reveals some metadata. Use full-disk encryption when that matters.
 
 OmaQ maintains a fingerprint-bound identity-presence record and a current recovery copy. A stale or fingerprint-mismatched copy is never restored automatically. Export a current identity bundle before moving or repairing an established identity.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -42,7 +42,9 @@ Source updates build an externally staged Git checkout before stopping the shell
 
 ## Know the passphrase boundary
 
-A passphrase encrypts the Tox savedata in `tox.save`. It does not encrypt Ratchet state, avatars, receipts, preferences, or chat history.
+A passphrase encrypts the Tox savedata in `tox.save` **and your chat history**. Setting a passphrase derives a second key with Argon2id, stores it wrapped in `~/.local/share/omaq/seal.key`, and rewrites every stored transcript so each message record is sealed with XChaCha20-Poly1305. Removing the passphrase reverses the migration and deletes the key. Without the passphrase, sealed transcripts are unreadable: they are never shown as plaintext and never silently reported as empty.
+
+It still does not encrypt Ratchet state, avatars, receipts, or preferences. In particular the Signal Ratchet identity private key under `~/.local/share/omaq/ratchet/` remains plaintext, because its lifetime is tied to identity replacement and recovery flows that must be reworked before it can be sealed safely; a disk image or backup therefore still reveals contact and session metadata. Use full-disk encryption when that matters.
 
 OmaQ maintains a fingerprint-bound identity-presence record and a current recovery copy. A stale or fingerprint-mismatched copy is never restored automatically. Export a current identity bundle before moving or repairing an established identity.
 

--- a/helper/omaq.c
+++ b/helper/omaq.c
@@ -3840,7 +3840,7 @@ static void reset_identity_runtime_state(void)
 	emit_invite_state("", 0, "clear", NULL);
 }
 
-#define IDENTITY_ARCHIVE_PATHS 18
+#define IDENTITY_ARCHIVE_PATHS 19
 
 typedef struct {
 	char source[IDENTITY_ARCHIVE_PATHS][700];
@@ -3973,7 +3973,10 @@ static int prepare_identity_archive(identity_state_archive *archive, const char 
 	const char *home_names[] = {
 		"history", "avatars", "files", "ratchet", "groups.tsv", "group-friends.tsv",
 		"direct-friends.tsv", "direct-add.pending", "direct-remove.pending",
-		"direct-state-reinvite.required"
+		"direct-state-reinvite.required",
+		/* The sealing key belongs to the identity whose history and
+		 * Ratchet state it protects; it must travel with them. */
+		"seal.key"
 	};
 	const char *state_names[] = {
 		"surfaces.jsonl", "", "auto-open.json", "unread.tsv", "group-bind.pending",
@@ -3994,9 +3997,14 @@ static int prepare_identity_archive(identity_state_archive *archive, const char 
 	}
 	memset(archive, 0, sizeof(*archive));
 	for (i = 0; i < IDENTITY_ARCHIVE_PATHS; i++) {
-		const char *base = i < 10 ? home_dir() : state_dir();
-		const char *name = i < 10 ? home_names[i] :
-			(i == 11 ? auto_open_name : state_names[i - 10]);
+		/* Derive the split from the tables so adding a home or state
+		 * entry cannot silently misalign the mapping. */
+		const int home_count =
+			(int)(sizeof(home_names) / sizeof(home_names[0]));
+		const char *base = i < home_count ? home_dir() : state_dir();
+		const char *name = i < home_count ? home_names[i] :
+			(i == home_count + 1 ? auto_open_name :
+			 state_names[i - home_count]);
 		if (snprintf(archive->source[i], sizeof(archive->source[i]), "%s/%s",
 			     base, name) >= (int)sizeof(archive->source[i]) ||
 		    snprintf(archive->archived[i], sizeof(archive->archived[i]),
@@ -10124,6 +10132,78 @@ static int activate_identity_guard(struct omaq_tox *tox)
 	return 0;
 }
 
+/* Passphrase-derived sealing of local state that the Tox savedata passphrase
+ * does not cover: chat history and Ratchet state. The key exists only while
+ * the identity is unlocked; nothing is sealed for identities without a
+ * passphrase, which preserves the previous behaviour for those users. */
+static omaq_seal_key g_seal;
+
+static void seal_install(const omaq_seal_key *key)
+{
+	omaq_store_set_seal_key(key);
+}
+
+static void seal_forget(void)
+{
+	seal_install(NULL);
+	omaq_seal_key_clear(&g_seal);
+}
+
+/* Install the sealing key for an unlocked identity.
+ *
+ * This never blocks startup. Enforcement lives at the data boundary instead:
+ * without the key, a sealed history record is a hard read error, never
+ * plaintext and never a silent empty result. Keeping the check there also
+ * means a transitional state - such as an identity restored from a recovery
+ * copy that predates the passphrase - cannot lock the user out. */
+static void seal_activate(const char *pass)
+{
+	seal_forget();
+	if (!omaq_seal_key_present(home_dir()))
+		return;
+	if (!pass || !pass[0] ||
+	    omaq_seal_key_open(home_dir(), pass, &g_seal) != 1) {
+		fprintf(stderr,
+			"omaq: sealed history present but the key did not "
+			"open; those conversations stay unreadable\n");
+		seal_forget();
+		return;
+	}
+	seal_install(&g_seal);
+}
+
+/* Start sealing for an identity that just gained a passphrase. */
+static int seal_enable(const char *pass)
+{
+	if (!pass || !pass[0])
+		return -1;
+	seal_forget();
+	if (omaq_seal_key_present(home_dir())) {
+		if (omaq_seal_key_open(home_dir(), pass, &g_seal) != 1)
+			return -1;
+	} else if (omaq_seal_key_create(home_dir(), pass, &g_seal) != 0) {
+		return -1;
+	}
+	seal_install(&g_seal);
+	return omaq_store_reseal_all(home_dir()) < 0 ? -1 : 0;
+}
+
+/* Stop sealing for an identity that dropped its passphrase: rewrite every
+ * sealed record as plaintext while the key can still read it, then discard
+ * the key file. */
+static int seal_disable(void)
+{
+	if (!g_seal.active) {
+		seal_forget();
+		return omaq_seal_key_destroy(home_dir());
+	}
+	omaq_store_set_seal_writes(0);
+	if (omaq_store_reseal_all(home_dir()) < 0)
+		return -1;
+	seal_forget();
+	return omaq_seal_key_destroy(home_dir());
+}
+
 static int load_tox(const char *pass)
 {
 	int err = 0, guard_rc;
@@ -10134,6 +10214,8 @@ static int load_tox(const char *pass)
 		return 1;
 	}
 	g_locked = 0;
+	if (g_tox)
+		seal_activate(pass);
 	if (!g_tox) {
 		if (g_identity_guard_state == OMAQ_IDENTITY_GUARD_RESTORED)
 			(void)omaq_identity_guard_reject_recovery(home_dir(), state_dir());
@@ -11021,12 +11103,23 @@ static int handle_op(const omaq_op *op, int *identity_ready, int owner_fd)
 			emit_identity_error("forbidden", op->id);
 			return 0;
 		}
+		/* The passphrase now also seals history and Ratchet state. */
+		if (seal_enable(op->passphrase) != 0) {
+			emit_error("seal_migration_failed");
+			emit_identity_action("protect", op->id, NULL, 1);
+			return 0;
+		}
 		emit_identity_action("protect", op->id, NULL, 1);
 		return 0;
 	}
 	if (strcmp(op->op, "identity.unprotect") == 0) {
 		if (!g_tox || omaq_identity_unprotect(g_tox, op->passphrase) != 0) {
 			emit_identity_error("forbidden", op->id);
+			return 0;
+		}
+		if (seal_disable() != 0) {
+			emit_error("seal_migration_failed");
+			emit_identity_action("unprotect", op->id, NULL, 0);
 			return 0;
 		}
 		emit_identity_action("unprotect", op->id, NULL, 0);

--- a/helper/omaq.c
+++ b/helper/omaq.c
@@ -10141,6 +10141,9 @@ static omaq_seal_key g_seal;
 static void seal_install(const omaq_seal_key *key)
 {
 	omaq_store_set_seal_key(key);
+#ifdef HAVE_SIGNAL
+	omaq_ratchet_set_seal_key(key);
+#endif
 }
 
 static void seal_forget(void)
@@ -10152,10 +10155,11 @@ static void seal_forget(void)
 /* Install the sealing key for an unlocked identity.
  *
  * This never blocks startup. Enforcement lives at the data boundary instead:
- * without the key, a sealed history record is a hard read error, never
- * plaintext and never a silent empty result. Keeping the check there also
- * means a transitional state - such as an identity restored from a recovery
- * copy that predates the passphrase - cannot lock the user out. */
+ * without the key, a sealed history record or Ratchet blob is a hard read
+ * error, never plaintext and never a silent empty result. Keeping the check
+ * there also means a transitional state - such as an identity restored from a
+ * recovery copy that predates the passphrase - cannot lock the user out; the
+ * Ratchet store is quarantined instead (see open_ratchet_store). */
 static void seal_activate(const char *pass)
 {
 	seal_forget();
@@ -10164,8 +10168,8 @@ static void seal_activate(const char *pass)
 	if (!pass || !pass[0] ||
 	    omaq_seal_key_open(home_dir(), pass, &g_seal) != 1) {
 		fprintf(stderr,
-			"omaq: sealed history present but the key did not "
-			"open; those conversations stay unreadable\n");
+			"omaq: sealed local state present but the key did not "
+			"open; it stays unreadable\n");
 		seal_forget();
 		return;
 	}
@@ -10185,7 +10189,13 @@ static int seal_enable(const char *pass)
 		return -1;
 	}
 	seal_install(&g_seal);
-	return omaq_store_reseal_all(home_dir()) < 0 ? -1 : 0;
+	if (omaq_store_reseal_all(home_dir()) < 0)
+		return -1;
+#ifdef HAVE_SIGNAL
+	if (omaq_ratchet_reseal_all(home_dir()) < 0)
+		return -1;
+#endif
+	return 0;
 }
 
 /* Stop sealing for an identity that dropped its passphrase: rewrite every
@@ -10198,11 +10208,72 @@ static int seal_disable(void)
 		return omaq_seal_key_destroy(home_dir());
 	}
 	omaq_store_set_seal_writes(0);
+#ifdef HAVE_SIGNAL
+	omaq_ratchet_set_seal_writes(0);
+#endif
 	if (omaq_store_reseal_all(home_dir()) < 0)
 		return -1;
+#ifdef HAVE_SIGNAL
+	if (omaq_ratchet_reseal_all(home_dir()) < 0)
+		return -1;
+#endif
 	seal_forget();
 	return omaq_seal_key_destroy(home_dir());
 }
+
+#ifdef HAVE_SIGNAL
+/* Sealed Ratchet state whose key is unavailable cannot be opened, and it must
+ * not be read as plaintext either. That happens only when a home ends up
+ * holding state sealed under a passphrase the current identity no longer
+ * carries - for example an identity restored from a recovery copy that
+ * predates the passphrase. Move the store aside rather than deleting it (the
+ * bytes stay recoverable if the passphrase turns up) and require fresh
+ * invitations, which is the same recovery OmaQ already performs when direct
+ * state has to be archived. */
+static int quarantine_locked_ratchet(void)
+{
+	char root[576], aside[700], token[33];
+	struct stat st;
+	time_t now = time(NULL);
+
+	if (snprintf(root, sizeof(root), "%s/ratchet", home_dir()) >= (int)sizeof(root))
+		return -1;
+	if (lstat(root, &st) != 0)
+		return 0;
+	if (rand_id(token, sizeof(token)) != 0)
+		return -1;
+	if (snprintf(aside, sizeof(aside), "%s.locked-%lld-%s", root,
+		     (long long)now, token) >= (int)sizeof(aside))
+		return -1;
+	if (lstat(aside, &st) == 0 || errno != ENOENT)
+		return -1;
+	if (rename(root, aside) != 0)
+		return -1;
+	if (fsync_directory(home_dir()) != 0)
+		return -1;
+	if (persist_reinvite_marker() != 0)
+		return -1;
+	g_direct_state_reinvite_required = 1;
+	fprintf(stderr,
+		"omaq: Ratchet state is sealed with an unavailable passphrase; "
+		"moved to %s and requiring fresh invitations\n", aside);
+	emit_error("direct_state_reinvite_required");
+	return 0;
+}
+
+/* Every Ratchet open goes through here so no path can open a store that is
+ * partly unreadable. */
+static struct omaq_ratchet *open_ratchet_store(void)
+{
+	int locked = omaq_ratchet_sealed_locked(home_dir());
+
+	if (locked < 0)
+		return NULL;
+	if (locked == 1 && quarantine_locked_ratchet() != 0)
+		return NULL;
+	return omaq_ratchet_open(home_dir());
+}
+#endif
 
 static int load_tox(const char *pass)
 {
@@ -10355,7 +10426,7 @@ static int restore_guarded_identity(const char *stage_save, const char *pass,
 		return -5;
 	}
 #ifdef HAVE_SIGNAL
-	g_ratchet = omaq_ratchet_open(home_dir());
+	g_ratchet = open_ratchet_store();
 	if (!g_ratchet) {
 		fail_direct_state_backend();
 		return -5;
@@ -11072,7 +11143,7 @@ static int handle_op(const omaq_op *op, int *identity_ready, int owner_fd)
 		}
 #ifdef HAVE_SIGNAL
 		if (!g_ratchet)
-			g_ratchet = omaq_ratchet_open(home_dir());
+			g_ratchet = open_ratchet_store();
 		if (!g_ratchet) {
 			omaq_tox_discard(g_tox);
 			g_tox = NULL;
@@ -11165,7 +11236,7 @@ static int handle_op(const omaq_op *op, int *identity_ready, int owner_fd)
 		}
 #ifdef HAVE_SIGNAL
 		if (!g_ratchet)
-			g_ratchet = omaq_ratchet_open(home_dir());
+			g_ratchet = open_ratchet_store();
 		if (!g_ratchet) {
 			fail_direct_state_backend();
 			g_shutdown_after_drain = 1;
@@ -13852,7 +13923,7 @@ static int handle_op(const omaq_op *op, int *identity_ready, int owner_fd)
 				goto identity_import_rollback;
 			}
 #ifdef HAVE_SIGNAL
-			g_ratchet = omaq_ratchet_open(home_dir());
+			g_ratchet = open_ratchet_store();
 			if (!g_ratchet) {
 				goto identity_import_rollback;
 			}
@@ -13959,7 +14030,7 @@ identity_import_rollback:
 			}
 #ifdef HAVE_SIGNAL
 			if (!g_ratchet && g_tox && rollback_ok)
-				g_ratchet = omaq_ratchet_open(home_dir());
+				g_ratchet = open_ratchet_store();
 			if (!g_ratchet)
 				rollback_ok = 0;
 #endif
@@ -14137,7 +14208,7 @@ static void start_backend(void)
 #endif
 #ifdef HAVE_SIGNAL
 	g_ratchet = g_tox && !g_direct_state_migration_failed &&
-		!g_identity_primary_uncertain ? omaq_ratchet_open(home_dir()) : NULL;
+		!g_identity_primary_uncertain ? open_ratchet_store() : NULL;
 	if (g_tox && !g_identity_primary_uncertain && !g_ratchet)
 		fail_direct_state_backend();
 #endif

--- a/helper/ratchet.h
+++ b/helper/ratchet.h
@@ -3,10 +3,25 @@
 
 #include <stddef.h>
 
+#include "seal.h"
+
 #define OMAQ_RK_HEX 64
 #define OMAQ_RATCHET_PEER_MAX 67
 #define OMAQ_RATCHET_RECORD_MAX (1024u * 1024u)
 #define OMAQ_RATCHET_DECRYPT_RECOVER (-2)
+
+/* Install or clear the passphrase-derived Ratchet-state sealing key. */
+void omaq_ratchet_set_seal_key(const omaq_seal_key *key);
+void omaq_ratchet_set_seal_writes(int enabled);
+int omaq_ratchet_seal_active(void);
+
+/* Rewrite every blob under $home/ratchet so it matches the current sealing
+ * state. Each file is replaced atomically. Returns files rewritten, or -1. */
+long omaq_ratchet_reseal_all(const char *home);
+
+/* 1 when $home/ratchet holds sealed blobs the installed key cannot open, so
+ * the store must be quarantined before it is opened. */
+int omaq_ratchet_sealed_locked(const char *home);
 
 int omaq_rk_ok(const char *hex64);
 int omaq_ratchet_peer_ok(const char *peer);

--- a/helper/ratchet_adapt.c
+++ b/helper/ratchet_adapt.c
@@ -2,6 +2,7 @@
 
 #define _DEFAULT_SOURCE
 #include "ratchet.h"
+#include "seal.h"
 
 #include <ctype.h>
 #include <dirent.h>
@@ -71,6 +72,7 @@ struct omaq_ratchet {
 };
 
 static int write_blob(const char *path, const uint8_t *p, size_t n);
+static int write_blob_raw(const char *path, const uint8_t *p, size_t n);
 static int read_blob(const char *path, uint8_t **out, size_t *n);
 static int fsync_parent(const char *path);
 static struct rec *rec_find(struct rec *a, int n, const char *name,
@@ -1356,13 +1358,217 @@ static int fsync_parent(const char *path)
 	return rc;
 }
 
+/* Passphrase-derived sealing for Ratchet state: sessions, signed prekeys and
+ * the identity private key. Inactive until the identity is unlocked with a
+ * passphrase. Sealed and legacy plaintext blobs may coexist while migration
+ * runs; a sealed blob is never returned without the key. */
+static omaq_seal_key g_ratchet_seal;
+static int g_ratchet_seal_writes = 1;
+
+void omaq_ratchet_set_seal_key(const omaq_seal_key *key)
+{
+	if (key && key->active)
+		g_ratchet_seal = *key;
+	else
+		omaq_seal_key_clear(&g_ratchet_seal);
+	g_ratchet_seal_writes = 1;
+}
+
+void omaq_ratchet_set_seal_writes(int enabled)
+{
+	g_ratchet_seal_writes = enabled ? 1 : 0;
+}
+
+int omaq_ratchet_seal_active(void)
+{
+	return g_ratchet_seal.active && g_ratchet_seal_writes;
+}
+
+static int blob_context(const char *path, char *out, size_t n)
+{
+	const char *base;
+	size_t len;
+
+	if (!path || !out)
+		return -1;
+	base = strrchr(path, '/');
+	base = base ? base + 1 : path;
+	len = strlen(base);
+	if (len == 0 || len >= n)
+		return -1;
+	memcpy(out, base, len + 1);
+	return 0;
+}
+
+/* Walk the Ratchet stores. `visit` returns 1 when it changed something, 0 when
+ * it did not, and -1 to abort. */
+typedef int (*ratchet_blob_visitor)(const char *path);
+
+static long walk_blob_directory(const char *dir, ratchet_blob_visitor visit)
+{
+	DIR *entries = opendir(dir);
+	struct dirent *entry;
+	long touched = 0;
+
+	if (!entries)
+		return errno == ENOENT ? 0 : -1;
+	while ((entry = readdir(entries)) != NULL) {
+		char path[768];
+		int rc;
+
+		if (entry->d_name[0] == '.' || strchr(entry->d_name, '/'))
+			continue;
+		if (snprintf(path, sizeof(path), "%s/%s", dir, entry->d_name) >=
+		    (int)sizeof(path))
+			continue;
+		rc = visit(path);
+		if (rc < 0) {
+			closedir(entries);
+			return -1;
+		}
+		touched += rc;
+	}
+	closedir(entries);
+	return touched;
+}
+
+static long walk_ratchet_stores(const char *home, ratchet_blob_visitor visit)
+{
+	static const char *subdirectories[] = { "sess", "ident", "boot",
+						"reply", "pre" };
+	char root[576], dir[640];
+	long touched = 0, rc;
+	size_t i;
+
+	if (!home)
+		return -1;
+	if (snprintf(root, sizeof(root), "%s/ratchet", home) >= (int)sizeof(root))
+		return -1;
+	rc = walk_blob_directory(root, visit);
+	if (rc < 0)
+		return -1;
+	touched += rc;
+	for (i = 0; i < sizeof(subdirectories) / sizeof(subdirectories[0]); i++) {
+		if (snprintf(dir, sizeof(dir), "%s/%s", root,
+			     subdirectories[i]) >= (int)sizeof(dir))
+			return -1;
+		rc = walk_blob_directory(dir, visit);
+		if (rc < 0)
+			return -1;
+		touched += rc;
+	}
+	return touched;
+}
+
+/* Rewrite one blob so it matches the current sealing state. */
+static int reseal_blob(const char *path)
+{
+	uint8_t *buf = NULL;
+	size_t n = 0;
+	int rc;
+
+	rc = read_blob(path, &buf, &n);
+	if (rc == BLOB_MISSING)
+		return 0;
+	if (rc != BLOB_FOUND)
+		return -1;
+	rc = write_blob(path, buf, n) == 0 ? 1 : -1;
+	explicit_bzero(buf, n);
+	free(buf);
+	return rc;
+}
+
+long omaq_ratchet_reseal_all(const char *home)
+{
+	return walk_ratchet_stores(home, reseal_blob);
+}
+
+/* 1 when the blob is sealed but the installed key cannot open it. */
+static int blob_is_locked(const char *path)
+{
+	uint8_t header[64];
+	struct stat st;
+	ssize_t got;
+	int fd, locked;
+
+	fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK);
+	if (fd < 0)
+		return 0;
+	if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+		close(fd);
+		return 0;
+	}
+	got = read(fd, header, sizeof(header));
+	close(fd);
+	if (got <= 0)
+		return 0;
+	if (!omaq_seal_is_blob(header, (size_t)got))
+		return 0;
+	if (!g_ratchet_seal.active)
+		return 1;
+	/* The key is installed: confirm it actually opens this blob. */
+	{
+		uint8_t *buf = NULL;
+		size_t n = 0;
+
+		locked = read_blob(path, &buf, &n) == BLOB_ERROR ? 1 : 0;
+		if (buf) {
+			explicit_bzero(buf, n);
+			free(buf);
+		}
+	}
+	return locked;
+}
+
+int omaq_ratchet_sealed_locked(const char *home)
+{
+	long rc = walk_ratchet_stores(home, blob_is_locked);
+
+	if (rc < 0)
+		return -1;
+	return rc > 0 ? 1 : 0;
+}
+
 static int write_blob(const char *path, const uint8_t *p, size_t n)
+{
+	char tmp[580];
+
+	if (!p || n == 0 || n > OMAQ_RATCHET_RECORD_MAX ||
+	    snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp))
+		return -1;
+	if (g_ratchet_seal.active && g_ratchet_seal_writes) {
+		char context[NAME_MAX + 1];
+		size_t sealed_cap = n + omaq_seal_blob_overhead();
+		uint8_t *sealed;
+		size_t sealed_len = 0;
+		int rc;
+
+		if (blob_context(path, context, sizeof(context)) != 0)
+			return -1;
+		sealed = malloc(sealed_cap);
+		if (!sealed)
+			return -1;
+		if (omaq_seal_blob(&g_ratchet_seal, context, p, n, sealed,
+				   sealed_cap, &sealed_len) != 0) {
+			explicit_bzero(sealed, sealed_cap);
+			free(sealed);
+			return -1;
+		}
+		rc = write_blob_raw(path, sealed, sealed_len);
+		explicit_bzero(sealed, sealed_cap);
+		free(sealed);
+		return rc;
+	}
+	return write_blob_raw(path, p, n);
+}
+
+static int write_blob_raw(const char *path, const uint8_t *p, size_t n)
 {
 	char tmp[580];
 	FILE *f;
 	int fd;
 
-	if (!p || n == 0 || n > OMAQ_RATCHET_RECORD_MAX ||
+	if (!p || n == 0 ||
 	    snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp))
 		return -1;
 	fd = open(tmp, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
@@ -1417,7 +1623,8 @@ static int read_blob(const char *path, uint8_t **out, size_t *n)
 	}
 	if (fstat(fileno(f), &st) != 0 || !S_ISREG(st.st_mode) ||
 	    st.st_uid != geteuid() || st.st_nlink != 1 || st.st_size <= 0 ||
-	    st.st_size > OMAQ_RATCHET_RECORD_MAX) {
+	    (uint64_t)st.st_size >
+		    (uint64_t)OMAQ_RATCHET_RECORD_MAX + omaq_seal_blob_overhead()) {
 		fclose(f);
 		return BLOB_ERROR;
 	}
@@ -1430,6 +1637,40 @@ static int read_blob(const char *path, uint8_t **out, size_t *n)
 	if (got != (size_t)st.st_size || fclose(f) != 0) {
 		free(buf);
 		return BLOB_ERROR;
+	}
+	if (omaq_seal_is_blob(buf, got)) {
+		/* Fail closed: sealed Ratchet state is never returned without
+		 * the passphrase-derived key, and never silently skipped. */
+		char context[NAME_MAX + 1];
+		uint8_t *opened;
+		size_t opened_len = 0;
+
+		if (!g_ratchet_seal.active ||
+		    blob_context(path, context, sizeof(context)) != 0) {
+			explicit_bzero(buf, got);
+			free(buf);
+			return BLOB_ERROR;
+		}
+		opened = malloc(got);
+		if (!opened) {
+			explicit_bzero(buf, got);
+			free(buf);
+			return BLOB_ERROR;
+		}
+		if (omaq_seal_open_blob(&g_ratchet_seal, context, buf, got,
+					opened, got, &opened_len) != 0 ||
+		    opened_len == 0 || opened_len > OMAQ_RATCHET_RECORD_MAX) {
+			explicit_bzero(buf, got);
+			explicit_bzero(opened, got);
+			free(buf);
+			free(opened);
+			return BLOB_ERROR;
+		}
+		explicit_bzero(buf, got);
+		free(buf);
+		buf = opened;
+		got = opened_len;
+		st.st_size = (off_t)opened_len;
 	}
 	*out = buf;
 	*n = got;

--- a/helper/seal.c
+++ b/helper/seal.c
@@ -1,0 +1,435 @@
+#define _DEFAULT_SOURCE
+#include "seal.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sodium.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define SEAL_NONCE crypto_aead_xchacha20poly1305_ietf_NPUBBYTES
+#define SEAL_TAG crypto_aead_xchacha20poly1305_ietf_ABYTES
+#define SEAL_SALT crypto_pwhash_SALTBYTES
+#define SEAL_BLOB_MAGIC "OMAQSEAL1"
+#define SEAL_BLOB_MAGIC_LEN 9
+#define SEAL_KEY_MAGIC "OMAQSEALKEY1"
+#define SEAL_KEY_MAGIC_LEN 12
+#define SEAL_KEY_AAD "omaq-seal-key-v1"
+/* Derivation cost: one Argon2id run per unlock. Interactive memory keeps the
+ * helper usable on small machines; the operation limit is raised to
+ * compensate. The parameters are stored in the key file so they can change
+ * without breaking existing installations. */
+#define SEAL_OPSLIMIT 4u
+#define SEAL_MEMLIMIT (64u * 1024u * 1024u)
+
+int omaq_seal_ready(void)
+{
+	static int state;
+
+	if (state == 0)
+		state = sodium_init() < 0 ? -1 : 1;
+	return state == 1;
+}
+
+void omaq_seal_key_clear(omaq_seal_key *key)
+{
+	if (!key)
+		return;
+	sodium_memzero(key->key, sizeof(key->key));
+	key->active = 0;
+}
+
+size_t omaq_seal_blob_overhead(void)
+{
+	return SEAL_BLOB_MAGIC_LEN + SEAL_NONCE + SEAL_TAG;
+}
+
+size_t omaq_seal_record_overhead(void)
+{
+	/* base64 of nonce+tag plus the record prefix, rounded generously. */
+	return OMAQ_SEAL_RECORD_PREFIX_LEN +
+	       sodium_base64_ENCODED_LEN(SEAL_NONCE + SEAL_TAG,
+					 sodium_base64_VARIANT_URLSAFE_NO_PADDING);
+}
+
+static int seal_key_path(const char *home, char *out, size_t n)
+{
+	if (!home || !out)
+		return -1;
+	if (snprintf(out, n, "%s/seal.key", home) >= (int)n)
+		return -1;
+	return 0;
+}
+
+static int derive_wrapping_key(const char *pass, const unsigned char *salt,
+			       unsigned long long ops, size_t mem,
+			       unsigned char out[OMAQ_SEAL_KEY_BYTES])
+{
+	if (!pass || !pass[0])
+		return -1;
+	if (crypto_pwhash(out, OMAQ_SEAL_KEY_BYTES, pass, strlen(pass), salt,
+			  ops, mem, crypto_pwhash_ALG_ARGON2ID13) != 0)
+		return -1;
+	return 0;
+}
+
+/* Key file layout:
+ *   magic(12) ops(8, big endian) mem(8, big endian) salt(16) nonce(24)
+ *   AEAD(data key)(32+16) */
+#define SEAL_KEY_FILE_BYTES \
+	(SEAL_KEY_MAGIC_LEN + 8 + 8 + SEAL_SALT + SEAL_NONCE + \
+	 OMAQ_SEAL_KEY_BYTES + SEAL_TAG)
+
+static void put_be64(unsigned char *out, unsigned long long value)
+{
+	int i;
+
+	for (i = 0; i < 8; i++)
+		out[i] = (unsigned char)(value >> (56 - i * 8));
+}
+
+static unsigned long long get_be64(const unsigned char *in)
+{
+	unsigned long long value = 0;
+	int i;
+
+	for (i = 0; i < 8; i++)
+		value = (value << 8) | in[i];
+	return value;
+}
+
+static int write_private_file(const char *path, const unsigned char *data,
+			      size_t len)
+{
+	char tmp[512];
+	int fd, dir_fd;
+	char dir[512];
+	char *slash;
+	ssize_t wrote;
+
+	if (snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp))
+		return -1;
+	(void)unlink(tmp);
+	fd = open(tmp, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, 0600);
+	if (fd < 0)
+		return -1;
+	if (fchmod(fd, 0600) != 0) {
+		close(fd);
+		(void)unlink(tmp);
+		return -1;
+	}
+	wrote = write(fd, data, len);
+	if (wrote < 0 || (size_t)wrote != len || fsync(fd) != 0 ||
+	    close(fd) != 0) {
+		(void)unlink(tmp);
+		return -1;
+	}
+	if (rename(tmp, path) != 0) {
+		(void)unlink(tmp);
+		return -1;
+	}
+	if (snprintf(dir, sizeof(dir), "%s", path) >= (int)sizeof(dir))
+		return -1;
+	slash = strrchr(dir, '/');
+	if (slash) {
+		*slash = '\0';
+		dir_fd = open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+		if (dir_fd >= 0) {
+			(void)fsync(dir_fd);
+			close(dir_fd);
+		}
+	}
+	return 0;
+}
+
+static int read_private_file(const char *path, unsigned char *out, size_t want)
+{
+	struct stat st;
+	int fd;
+	ssize_t got;
+
+	fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK);
+	if (fd < 0)
+		return errno == ENOENT ? 0 : -1;
+	if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) ||
+	    st.st_uid != geteuid() || st.st_nlink != 1 ||
+	    (st.st_mode & 0077) != 0 || (size_t)st.st_size != want) {
+		close(fd);
+		return -1;
+	}
+	got = read(fd, out, want);
+	close(fd);
+	if (got < 0 || (size_t)got != want)
+		return -1;
+	return 1;
+}
+
+int omaq_seal_key_present(const char *home)
+{
+	char path[512];
+	struct stat st;
+
+	if (seal_key_path(home, path, sizeof(path)) != 0)
+		return 0;
+	return stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+
+int omaq_seal_key_create(const char *home, const char *pass, omaq_seal_key *out)
+{
+	unsigned char file[SEAL_KEY_FILE_BYTES];
+	unsigned char wrapping[OMAQ_SEAL_KEY_BYTES];
+	unsigned char data_key[OMAQ_SEAL_KEY_BYTES];
+	unsigned char *salt, *nonce, *body;
+	unsigned long long body_len = 0;
+	char path[512];
+	int rc = -1;
+
+	if (!omaq_seal_ready() || !out || !pass || !pass[0])
+		return -1;
+	if (seal_key_path(home, path, sizeof(path)) != 0)
+		return -1;
+	if (omaq_seal_key_present(home))
+		return -1;
+	memset(file, 0, sizeof(file));
+	memcpy(file, SEAL_KEY_MAGIC, SEAL_KEY_MAGIC_LEN);
+	put_be64(file + SEAL_KEY_MAGIC_LEN, SEAL_OPSLIMIT);
+	put_be64(file + SEAL_KEY_MAGIC_LEN + 8, SEAL_MEMLIMIT);
+	salt = file + SEAL_KEY_MAGIC_LEN + 16;
+	nonce = salt + SEAL_SALT;
+	body = nonce + SEAL_NONCE;
+	randombytes_buf(salt, SEAL_SALT);
+	randombytes_buf(nonce, SEAL_NONCE);
+	randombytes_buf(data_key, sizeof(data_key));
+	if (derive_wrapping_key(pass, salt, SEAL_OPSLIMIT, SEAL_MEMLIMIT,
+				wrapping) != 0)
+		goto done;
+	if (crypto_aead_xchacha20poly1305_ietf_encrypt(
+		    body, &body_len, data_key, sizeof(data_key),
+		    (const unsigned char *)SEAL_KEY_AAD, strlen(SEAL_KEY_AAD),
+		    NULL, nonce, wrapping) != 0)
+		goto done;
+	if (body_len != OMAQ_SEAL_KEY_BYTES + SEAL_TAG)
+		goto done;
+	if (write_private_file(path, file, sizeof(file)) != 0)
+		goto done;
+	memcpy(out->key, data_key, sizeof(data_key));
+	out->active = 1;
+	rc = 0;
+done:
+	sodium_memzero(wrapping, sizeof(wrapping));
+	sodium_memzero(data_key, sizeof(data_key));
+	sodium_memzero(file, sizeof(file));
+	return rc;
+}
+
+int omaq_seal_key_open(const char *home, const char *pass, omaq_seal_key *out)
+{
+	unsigned char file[SEAL_KEY_FILE_BYTES];
+	unsigned char wrapping[OMAQ_SEAL_KEY_BYTES];
+	unsigned char data_key[OMAQ_SEAL_KEY_BYTES];
+	const unsigned char *salt, *nonce, *body;
+	unsigned long long plain_len = 0;
+	unsigned long long ops;
+	unsigned long long mem;
+	char path[512];
+	int present, rc = -1;
+
+	if (!omaq_seal_ready() || !out)
+		return -1;
+	if (seal_key_path(home, path, sizeof(path)) != 0)
+		return -1;
+	present = read_private_file(path, file, sizeof(file));
+	if (present <= 0)
+		return present;
+	if (!pass || !pass[0])
+		goto done;
+	if (sodium_memcmp(file, SEAL_KEY_MAGIC, SEAL_KEY_MAGIC_LEN) != 0)
+		goto done;
+	ops = get_be64(file + SEAL_KEY_MAGIC_LEN);
+	mem = get_be64(file + SEAL_KEY_MAGIC_LEN + 8);
+	/* Bound the stored cost so a tampered key file cannot turn an unlock
+	 * into a denial of service. */
+	if (ops == 0 || ops > 16 || mem < 8u * 1024u * 1024u ||
+	    mem > 512u * 1024u * 1024u)
+		goto done;
+	salt = file + SEAL_KEY_MAGIC_LEN + 16;
+	nonce = salt + SEAL_SALT;
+	body = nonce + SEAL_NONCE;
+	if (derive_wrapping_key(pass, salt, ops, (size_t)mem, wrapping) != 0)
+		goto done;
+	if (crypto_aead_xchacha20poly1305_ietf_decrypt(
+		    data_key, &plain_len, NULL, body,
+		    OMAQ_SEAL_KEY_BYTES + SEAL_TAG,
+		    (const unsigned char *)SEAL_KEY_AAD, strlen(SEAL_KEY_AAD),
+		    nonce, wrapping) != 0)
+		goto done;
+	if (plain_len != OMAQ_SEAL_KEY_BYTES)
+		goto done;
+	memcpy(out->key, data_key, sizeof(data_key));
+	out->active = 1;
+	rc = 1;
+done:
+	sodium_memzero(wrapping, sizeof(wrapping));
+	sodium_memzero(data_key, sizeof(data_key));
+	sodium_memzero(file, sizeof(file));
+	return rc;
+}
+
+int omaq_seal_key_destroy(const char *home)
+{
+	char path[512];
+
+	if (seal_key_path(home, path, sizeof(path)) != 0)
+		return -1;
+	if (unlink(path) != 0 && errno != ENOENT)
+		return -1;
+	return 0;
+}
+
+int omaq_seal_is_record(const char *line)
+{
+	return line && strncmp(line, OMAQ_SEAL_RECORD_PREFIX,
+			       OMAQ_SEAL_RECORD_PREFIX_LEN) == 0;
+}
+
+int omaq_seal_record(const omaq_seal_key *key, const char *context,
+		     const char *plain, char *out, size_t out_size)
+{
+	unsigned char *buffer;
+	unsigned long long cipher_len = 0;
+	size_t plain_len, buffer_len, encoded_len;
+	int rc = -1;
+
+	if (!omaq_seal_ready() || !key || !key->active || !context || !plain ||
+	    !out)
+		return -1;
+	plain_len = strlen(plain);
+	buffer_len = SEAL_NONCE + plain_len + SEAL_TAG;
+	encoded_len = sodium_base64_ENCODED_LEN(
+		buffer_len, sodium_base64_VARIANT_URLSAFE_NO_PADDING);
+	if (out_size <= OMAQ_SEAL_RECORD_PREFIX_LEN + encoded_len)
+		return -1;
+	buffer = malloc(buffer_len);
+	if (!buffer)
+		return -1;
+	randombytes_buf(buffer, SEAL_NONCE);
+	if (crypto_aead_xchacha20poly1305_ietf_encrypt(
+		    buffer + SEAL_NONCE, &cipher_len,
+		    (const unsigned char *)plain, plain_len,
+		    (const unsigned char *)context, strlen(context), NULL,
+		    buffer, key->key) != 0)
+		goto done;
+	if (cipher_len != plain_len + SEAL_TAG)
+		goto done;
+	memcpy(out, OMAQ_SEAL_RECORD_PREFIX, OMAQ_SEAL_RECORD_PREFIX_LEN);
+	if (!sodium_bin2base64(out + OMAQ_SEAL_RECORD_PREFIX_LEN,
+			       out_size - OMAQ_SEAL_RECORD_PREFIX_LEN, buffer,
+			       SEAL_NONCE + (size_t)cipher_len,
+			       sodium_base64_VARIANT_URLSAFE_NO_PADDING))
+		goto done;
+	rc = 0;
+done:
+	sodium_memzero(buffer, buffer_len);
+	free(buffer);
+	return rc;
+}
+
+int omaq_seal_open_record(const omaq_seal_key *key, const char *context,
+			  const char *line, char *out, size_t out_size)
+{
+	unsigned char *buffer;
+	const char *encoded;
+	size_t encoded_len, buffer_cap, buffer_len = 0;
+	unsigned long long plain_len = 0;
+	int rc = -1;
+
+	if (!omaq_seal_ready() || !key || !key->active || !context ||
+	    !omaq_seal_is_record(line) || !out)
+		return -1;
+	encoded = line + OMAQ_SEAL_RECORD_PREFIX_LEN;
+	encoded_len = strlen(encoded);
+	buffer_cap = encoded_len / 4 * 3 + 4;
+	if (buffer_cap < SEAL_NONCE + SEAL_TAG)
+		return -1;
+	buffer = malloc(buffer_cap);
+	if (!buffer)
+		return -1;
+	if (sodium_base642bin(buffer, buffer_cap, encoded, encoded_len, NULL,
+			      &buffer_len, NULL,
+			      sodium_base64_VARIANT_URLSAFE_NO_PADDING) != 0)
+		goto done;
+	if (buffer_len < SEAL_NONCE + SEAL_TAG)
+		goto done;
+	if (out_size <= buffer_len - SEAL_NONCE - SEAL_TAG)
+		goto done;
+	if (crypto_aead_xchacha20poly1305_ietf_decrypt(
+		    (unsigned char *)out, &plain_len, NULL, buffer + SEAL_NONCE,
+		    buffer_len - SEAL_NONCE, (const unsigned char *)context,
+		    strlen(context), buffer, key->key) != 0)
+		goto done;
+	out[plain_len] = '\0';
+	/* A record must not smuggle a newline or NUL back into a line store. */
+	if (strlen(out) != plain_len || memchr(out, '\n', (size_t)plain_len))
+		goto done;
+	rc = 0;
+done:
+	sodium_memzero(buffer, buffer_cap);
+	free(buffer);
+	return rc;
+}
+
+int omaq_seal_is_blob(const unsigned char *data, size_t len)
+{
+	return data && len >= SEAL_BLOB_MAGIC_LEN &&
+	       memcmp(data, SEAL_BLOB_MAGIC, SEAL_BLOB_MAGIC_LEN) == 0;
+}
+
+int omaq_seal_blob(const omaq_seal_key *key, const char *context,
+		   const unsigned char *plain, size_t plain_len,
+		   unsigned char *out, size_t out_size, size_t *out_len)
+{
+	unsigned long long cipher_len = 0;
+
+	if (!omaq_seal_ready() || !key || !key->active || !context || !out ||
+	    !out_len || (!plain && plain_len))
+		return -1;
+	if (out_size < SEAL_BLOB_MAGIC_LEN + SEAL_NONCE + plain_len + SEAL_TAG)
+		return -1;
+	memcpy(out, SEAL_BLOB_MAGIC, SEAL_BLOB_MAGIC_LEN);
+	randombytes_buf(out + SEAL_BLOB_MAGIC_LEN, SEAL_NONCE);
+	if (crypto_aead_xchacha20poly1305_ietf_encrypt(
+		    out + SEAL_BLOB_MAGIC_LEN + SEAL_NONCE, &cipher_len, plain,
+		    plain_len, (const unsigned char *)context, strlen(context),
+		    NULL, out + SEAL_BLOB_MAGIC_LEN, key->key) != 0)
+		return -1;
+	*out_len = SEAL_BLOB_MAGIC_LEN + SEAL_NONCE + (size_t)cipher_len;
+	return 0;
+}
+
+int omaq_seal_open_blob(const omaq_seal_key *key, const char *context,
+			const unsigned char *data, size_t len,
+			unsigned char *out, size_t out_size, size_t *out_len)
+{
+	unsigned long long plain_len = 0;
+	size_t body;
+
+	if (!omaq_seal_ready() || !key || !key->active || !context || !out ||
+	    !out_len || !omaq_seal_is_blob(data, len))
+		return -1;
+	if (len < SEAL_BLOB_MAGIC_LEN + SEAL_NONCE + SEAL_TAG)
+		return -1;
+	body = len - SEAL_BLOB_MAGIC_LEN - SEAL_NONCE;
+	if (out_size < body - SEAL_TAG)
+		return -1;
+	if (crypto_aead_xchacha20poly1305_ietf_decrypt(
+		    out, &plain_len, NULL,
+		    data + SEAL_BLOB_MAGIC_LEN + SEAL_NONCE, body,
+		    (const unsigned char *)context, strlen(context),
+		    data + SEAL_BLOB_MAGIC_LEN, key->key) != 0)
+		return -1;
+	*out_len = (size_t)plain_len;
+	return 0;
+}

--- a/helper/seal.h
+++ b/helper/seal.h
@@ -1,0 +1,79 @@
+#ifndef OMAQ_SEAL_H
+#define OMAQ_SEAL_H
+
+#include <stddef.h>
+
+/* Passphrase-derived encryption for local state that the Tox savedata
+ * passphrase does not cover: chat history and Ratchet state.
+ *
+ * A random 32-byte data key is generated once per home and wrapped in
+ * "$home/seal.key" with a key derived from the identity passphrase using
+ * Argon2id. History records and Ratchet blobs are then sealed with
+ * XChaCha20-Poly1305. Nothing is sealed while no passphrase is set, which
+ * matches the existing behaviour for unprotected identities.
+ *
+ * Everything here fails closed: a sealed record can never be read as
+ * plaintext, and an authentication failure is an error, never a skip. */
+
+#define OMAQ_SEAL_KEY_BYTES 32
+#define OMAQ_SEAL_RECORD_PREFIX "#1:"
+#define OMAQ_SEAL_RECORD_PREFIX_LEN 3
+
+/* Session key material. Callers keep one of these; it never reaches disk. */
+typedef struct {
+	unsigned char key[OMAQ_SEAL_KEY_BYTES];
+	int active;
+} omaq_seal_key;
+
+/* 1 = library ready, 0 = unavailable. Safe to call repeatedly. */
+int omaq_seal_ready(void);
+
+/* Wipe key material. */
+void omaq_seal_key_clear(omaq_seal_key *key);
+
+/* Create "$home/seal.key" wrapping a fresh random data key under the
+ * passphrase, and return that data key. Refuses to overwrite an existing
+ * key file. 0 = ok, -1 = failure. */
+int omaq_seal_key_create(const char *home, const char *pass, omaq_seal_key *out);
+
+/* Load and unwrap "$home/seal.key". 1 = loaded, 0 = no key file (nothing is
+ * sealed in this home), -1 = present but unusable (wrong passphrase or
+ * tampering). */
+int omaq_seal_key_open(const char *home, const char *pass, omaq_seal_key *out);
+
+/* Remove "$home/seal.key". 0 = ok (also when already absent). */
+int omaq_seal_key_destroy(const char *home);
+
+/* 1 when "$home/seal.key" exists. */
+int omaq_seal_key_present(const char *home);
+
+/* Record sealing for line-oriented stores. `context` binds the record to its
+ * conversation so a record cannot be replayed into another conversation.
+ * omaq_seal_record writes OMAQ_SEAL_RECORD_PREFIX + base64 into `out`. */
+int omaq_seal_record(const omaq_seal_key *key, const char *context,
+		     const char *plain, char *out, size_t out_size);
+
+/* 1 when the line is a sealed record. */
+int omaq_seal_is_record(const char *line);
+
+/* Reverse of omaq_seal_record. 0 = ok, -1 = not authentic or malformed. */
+int omaq_seal_open_record(const omaq_seal_key *key, const char *context,
+			  const char *line, char *out, size_t out_size);
+
+/* Whole-buffer sealing for blob files (Ratchet state). */
+int omaq_seal_blob(const omaq_seal_key *key, const char *context,
+		   const unsigned char *plain, size_t plain_len,
+		   unsigned char *out, size_t out_size, size_t *out_len);
+
+/* 1 when the buffer carries the blob header. */
+int omaq_seal_is_blob(const unsigned char *data, size_t len);
+
+int omaq_seal_open_blob(const omaq_seal_key *key, const char *context,
+			const unsigned char *data, size_t len,
+			unsigned char *out, size_t out_size, size_t *out_len);
+
+/* Ciphertext growth over plaintext for blobs and records. */
+size_t omaq_seal_blob_overhead(void);
+size_t omaq_seal_record_overhead(void);
+
+#endif

--- a/helper/store.c
+++ b/helper/store.c
@@ -1,5 +1,6 @@
 #define _DEFAULT_SOURCE
 #include "store.h"
+#include "seal.h"
 #include "json_io.h"
 
 #include <ctype.h>
@@ -10,12 +11,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/random.h>
+#include <dirent.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 #define ROTATE_BYTES (2 * 1024 * 1024)
 #define UNREAD_STATE_BYTES (1024 * 1024)
 #define STORE_LINE_MAX 16384u
+/* A sealed record is base64 of nonce+ciphertext+tag, so it is about a third
+ * longer than the plaintext line it replaces. */
+#define STORE_SEALED_LINE_MAX (STORE_LINE_MAX * 2u)
 #define GROUP_REACTION_ACTORS_MAX 32
 #define MESSAGE_INDEX_SLOTS 8
 #define MESSAGE_INDEX_BLOOM_BYTES (128u * 1024u)
@@ -167,6 +172,77 @@ static int mkdir_p(const char *path)
 	return -1;
 }
 
+/* Passphrase-derived sealing for chat history. Inactive until the identity is
+ * unlocked with a passphrase; unprotected identities keep the previous
+ * plaintext format. Sealed and plaintext records may coexist in one file
+ * while migration runs, so reads accept both, but a sealed record is never
+ * readable without the key. */
+static omaq_seal_key g_store_seal;
+/* Reads always use the installed key; writes can be switched to plaintext so
+ * an identity that drops its passphrase can be migrated back in one pass. */
+static int g_store_seal_writes = 1;
+
+void omaq_store_set_seal_key(const omaq_seal_key *key)
+{
+	if (key && key->active)
+		g_store_seal = *key;
+	else
+		omaq_seal_key_clear(&g_store_seal);
+	g_store_seal_writes = 1;
+}
+
+void omaq_store_set_seal_writes(int enabled)
+{
+	g_store_seal_writes = enabled ? 1 : 0;
+}
+
+int omaq_store_seal_active(void)
+{
+	return g_store_seal.active && g_store_seal_writes;
+}
+
+/* The directory holding a history file is the conversation id, so it is a
+ * stable binding that survives log rotation. */
+static int seal_context_from_path(const char *path, char *out, size_t n)
+{
+	const char *last, *prev;
+	size_t len;
+
+	if (!path || !out)
+		return -1;
+	last = strrchr(path, '/');
+	if (!last || last == path)
+		return -1;
+	prev = NULL;
+	for (const char *scan = path; scan < last; scan++) {
+		if (*scan == '/')
+			prev = scan;
+	}
+	if (!prev)
+		return -1;
+	len = (size_t)(last - prev - 1);
+	if (len == 0 || len >= n)
+		return -1;
+	memcpy(out, prev + 1, len);
+	out[len] = '\0';
+	return 0;
+}
+
+static int write_history_line(FILE *f, const char *path, const char *line)
+{
+	char context[256];
+	char sealed[STORE_SEALED_LINE_MAX + 2];
+
+	if (!g_store_seal.active || !g_store_seal_writes)
+		return fprintf(f, "%s\n", line) < 0 ? -1 : 0;
+	if (seal_context_from_path(path, context, sizeof(context)) != 0)
+		return -1;
+	if (omaq_seal_record(&g_store_seal, context, line, sealed,
+			     sizeof(sealed)) != 0)
+		return -1;
+	return fprintf(f, "%s\n", sealed) < 0 ? -1 : 0;
+}
+
 static int hist_dir(const char *home, const char *conv_id, char *buf, size_t n)
 {
 	if (!home || !conv_id || !buf)
@@ -189,6 +265,7 @@ static int hist_file(const char *home, const char *conv_id, char *buf, size_t n)
 }
 
 static int read_lines(const char *path, char ***lines, size_t *n, size_t *cap);
+static void reset_read_lines(char ***lines, size_t *n, size_t *cap);
 static int history_line_id(const char *line, char *out, size_t outn);
 
 struct message_index_entry {
@@ -535,7 +612,7 @@ static int update_file_message(const char *path, const char *id, const char *tex
 	if (fchmod(fileno(f), 0600) != 0)
 		goto close_fail;
 	for (i = 0; i < n; i++)
-		if (fprintf(f, "%s\n", lines[i]) < 0)
+		if (write_history_line(f, path, lines[i]) != 0)
 			goto close_fail;
 	if (fclose(f) != 0)
 		goto fail_tmp;
@@ -596,7 +673,7 @@ static int update_file_receipt(const char *path, const char *id, const char *sta
 	if (fchmod(fileno(f), 0600) != 0)
 		goto close_fail;
 	for (i = 0; i < n; i++)
-		if (fprintf(f, "%s\n", lines[i]) < 0)
+		if (write_history_line(f, path, lines[i]) != 0)
 			goto close_fail;
 	if (fclose(f) != 0)
 		goto fail_tmp;
@@ -692,7 +769,7 @@ static int update_file_group_receipt(const char *path, const char *id,
 	if (fchmod(fileno(f), 0600) != 0)
 		goto close_fail;
 	for (i = 0; i < n; i++)
-		if (fprintf(f, "%s\n", lines[i]) < 0)
+		if (write_history_line(f, path, lines[i]) != 0)
 			goto close_fail;
 	if (fclose(f) != 0)
 		goto fail_tmp;
@@ -791,7 +868,7 @@ static int update_file_reaction(const char *path, const char *id, const char *em
 	if (fchmod(fileno(f), 0600) != 0)
 		goto close_fail;
 	for (i = 0; i < n; i++) {
-		if (fprintf(f, "%s\n", lines[i]) < 0)
+		if (write_history_line(f, path, lines[i]) != 0)
 			goto close_fail;
 	}
 	if (fclose(f) != 0)
@@ -1168,6 +1245,113 @@ int omaq_store_clear(const char *home, const char *conv_id)
 	return rc;
 }
 
+/* Rewrite one history file so every record matches the current sealing
+ * state. The rewrite is atomic, so a crash leaves either the old or the new
+ * file, never a partial one. */
+static int reseal_file(const char *path)
+{
+	char **lines = NULL;
+	char tmp[640];
+	size_t n = 0, cap = 0, i;
+	FILE *f;
+
+	if (read_lines(path, &lines, &n, &cap) != 0)
+		return -1;
+	if (n == 0) {
+		reset_read_lines(&lines, &n, &cap);
+		return 0;
+	}
+	if (snprintf(tmp, sizeof(tmp), "%s.tmp.%ld", path, (long)getpid()) >=
+	    (int)sizeof(tmp)) {
+		reset_read_lines(&lines, &n, &cap);
+		return -1;
+	}
+	f = safe_fopen(tmp, "w");
+	if (!f) {
+		reset_read_lines(&lines, &n, &cap);
+		return -1;
+	}
+	if (fchmod(fileno(f), 0600) != 0)
+		goto fail;
+	for (i = 0; i < n; i++) {
+		if (write_history_line(f, path, lines[i]) != 0)
+			goto fail;
+	}
+	if (fflush(f) != 0 || fsync(fileno(f)) != 0 || fclose(f) != 0) {
+		safe_unlink(tmp);
+		reset_read_lines(&lines, &n, &cap);
+		return -1;
+	}
+	if (safe_rename(tmp, path) != 0) {
+		safe_unlink(tmp);
+		reset_read_lines(&lines, &n, &cap);
+		return -1;
+	}
+	reset_read_lines(&lines, &n, &cap);
+	return 1;
+fail:
+	fclose(f);
+	safe_unlink(tmp);
+	reset_read_lines(&lines, &n, &cap);
+	return -1;
+}
+
+long omaq_store_reseal_all(const char *home)
+{
+	char root[512], dir[576], path[704];
+	DIR *conversations;
+	struct dirent *entry;
+	long rewritten = 0;
+
+	if (!home)
+		return -1;
+	if (snprintf(root, sizeof(root), "%s/history", home) >= (int)sizeof(root))
+		return -1;
+	conversations = opendir(root);
+	if (!conversations)
+		return errno == ENOENT ? 0 : -1;
+	while ((entry = readdir(conversations)) != NULL) {
+		struct stat st;
+		int index;
+
+		if (entry->d_name[0] == '.')
+			continue;
+		if (strchr(entry->d_name, '/'))
+			continue;
+		if (snprintf(dir, sizeof(dir), "%s/%s", root, entry->d_name) >=
+		    (int)sizeof(dir))
+			continue;
+		/* messages.jsonl plus the rotated generation. safe_stat accepts
+		 * only owner-owned regular files, so a non-conversation entry
+		 * simply yields no history paths. */
+		for (index = 0; index < 2; index++) {
+			int rc;
+
+			if (index == 0)
+				rc = snprintf(path, sizeof(path),
+					      "%s/messages.jsonl", dir);
+			else
+				rc = snprintf(path, sizeof(path),
+					      "%s/messages.jsonl.1", dir);
+			if (rc >= (int)sizeof(path))
+				continue;
+			if (safe_stat(path, &st) != 0 || !S_ISREG(st.st_mode))
+				continue;
+			rc = reseal_file(path);
+			if (rc < 0) {
+				closedir(conversations);
+				return -1;
+			}
+			rewritten += rc;
+		}
+		message_index_invalidate(home, entry->d_name);
+	}
+	closedir(conversations);
+	if (fsync_dir(root) != 0)
+		return -1;
+	return rewritten;
+}
+
 int omaq_store_append(const char *home, const char *conv_id, const char *line)
 {
 	char dir[512], path[576], rot[580];
@@ -1201,7 +1385,7 @@ int omaq_store_append(const char *home, const char *conv_id, const char *line)
 		fclose(f);
 		return -1;
 	}
-	if (fprintf(f, "%s\n", line) < 0) {
+	if (write_history_line(f, path, line) != 0) {
 		fclose(f);
 		return -1;
 	}
@@ -1232,7 +1416,9 @@ static void reset_read_lines(char ***lines, size_t *n, size_t *cap)
 static int read_lines(const char *path, char ***lines, size_t *n, size_t *cap)
 {
 	FILE *f;
-	char buf[STORE_LINE_MAX + 2];
+	char buf[STORE_SEALED_LINE_MAX + 2];
+	char opened[STORE_LINE_MAX + 1];
+	char context[256];
 
 	f = safe_fopen(path, "r");
 	if (!f)
@@ -1240,12 +1426,37 @@ static int read_lines(const char *path, char ***lines, size_t *n, size_t *cap)
 	while (fgets(buf, sizeof(buf), f)) {
 		size_t len = strlen(buf);
 		char *copy;
-		if (len == 0 || len > STORE_LINE_MAX || buf[len - 1] != '\n') {
+		if (len == 0 || len > STORE_SEALED_LINE_MAX ||
+		    buf[len - 1] != '\n') {
 			fclose(f);
 			reset_read_lines(lines, n, cap);
 			return -1;
 		}
 		buf[--len] = '\0';
+		if (omaq_seal_is_record(buf)) {
+			/* Fail closed: a sealed record is never returned as
+			 * plaintext, and never skipped. */
+			if (!g_store_seal.active ||
+			    seal_context_from_path(path, context,
+						   sizeof(context)) != 0 ||
+			    omaq_seal_open_record(&g_store_seal, context, buf,
+						  opened, sizeof(opened)) != 0) {
+				fclose(f);
+				reset_read_lines(lines, n, cap);
+				return -1;
+			}
+			len = strlen(opened);
+			if (len == 0 || len > STORE_LINE_MAX) {
+				fclose(f);
+				reset_read_lines(lines, n, cap);
+				return -1;
+			}
+			memcpy(buf, opened, len + 1);
+		} else if (len > STORE_LINE_MAX) {
+			fclose(f);
+			reset_read_lines(lines, n, cap);
+			return -1;
+		}
 		if (omaq_json_validate(buf) != 0) {
 			fclose(f);
 			reset_read_lines(lines, n, cap);

--- a/helper/store.h
+++ b/helper/store.h
@@ -2,6 +2,8 @@
 #define OMAQ_STORE_H
 
 #include <stddef.h>
+
+#include "seal.h"
 #include "conversation.h"
 
 #define OMAQ_STORE_READ_IDS_MAX 4096u
@@ -11,6 +13,18 @@ typedef struct {
 } omaq_store_message_id;
 
 /* Only this module opens history files. */
+
+/* Install or clear the passphrase-derived history sealing key. Passing NULL
+ * or an inactive key returns the store to plaintext for future writes. */
+void omaq_store_set_seal_key(const omaq_seal_key *key);
+void omaq_store_set_seal_writes(int enabled);
+int omaq_store_seal_active(void);
+
+/* Rewrite every history file under $home so its records match the current
+ * sealing state: sealed when a key is installed, plaintext when it is not.
+ * Each file is replaced atomically, so an interrupted run leaves a mix that
+ * reads correctly. Returns the number of files rewritten, or -1. */
+long omaq_store_reseal_all(const char *home);
 
 int omaq_store_append(const char *home, const char *conv_id, const char *line);
 /* Removes current and rotated history for exactly one conversation. */

--- a/tests/history-seal.sh
+++ b/tests/history-seal.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
-# Setting an identity passphrase must also seal chat history at rest, and
-# removing it must return the history to plaintext. No network required.
+# Setting an identity passphrase must also seal chat history and Ratchet state
+# at rest, and removing it must return both to plaintext. Sealed Ratchet state
+# whose key is gone must be quarantined, never read as plaintext and never
+# silently regenerated. No network required.
 set -eu
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 bin=${1:-$root/helper/omaq}
@@ -47,6 +49,28 @@ mkdir -p "$home/history/7"
 printf '{"id":"m1","from":"peer","text":"attack at dawn"}\n' >"$home/history/7/messages.jsonl"
 chmod 600 "$home/history/7/messages.jsonl"
 
+# Every regular file under $1 must begin with the seal magic.
+assert_sealed() {
+	found=0
+	for f in $(find "$1" -type f 2>/dev/null); do
+		found=1
+		if [ "$(head -c 9 -- "$f")" != "OMAQSEAL1" ]; then
+			echo "history-seal: $f is not sealed" >&2
+			exit 1
+		fi
+	done
+	[ "$found" -eq 1 ] || { echo "history-seal: no files under $1" >&2; exit 1; }
+}
+
+assert_plaintext() {
+	for f in $(find "$1" -type f 2>/dev/null); do
+		if [ "$(head -c 9 -- "$f")" = "OMAQSEAL1" ]; then
+			echo "history-seal: $f is still sealed" >&2
+			exit 1
+		fi
+	done
+}
+
 wait_for() {
 	i=0
 	while [ "$i" -lt 200 ]; do
@@ -78,6 +102,12 @@ if grep -a -r -q "attack at dawn" "$home" 2>/dev/null; then
 	echo "history-seal: plaintext transcript left on disk" >&2
 	exit 1
 fi
+# Ratchet state - including the Signal identity private key - is sealed too.
+[ -f "$home/ratchet/identity" ] || {
+	echo "history-seal: no Ratchet identity blob" >&2
+	exit 1
+}
+assert_sealed "$home/ratchet"
 
 printf '%s\n' '{"op":"identity.unprotect","passphrase":"a strong passphrase","id":"hs-unprotect"}' >&3
 wait_for '"request":"hs-unprotect"'
@@ -85,6 +115,63 @@ wait_for '"request":"hs-unprotect"'
 [ -f "$home/seal.key" ] && { echo "history-seal: seal key survived unprotect" >&2; exit 1; }
 grep -a -q "attack at dawn" "$home/history/7/messages.jsonl" || {
 	echo "history-seal: history not restored after unprotect" >&2
+	exit 1
+}
+assert_plaintext "$home/ratchet"
+
+# Quarantine: seal again, then lose the key and restart. The sealed Ratchet
+# store must be moved aside and fresh invitations required - never opened as
+# if it were empty.
+printf '%s\n' '{"op":"identity.protect","passphrase":"a strong passphrase","id":"hs-protect2"}' >&3
+wait_for '"request":"hs-protect2"'
+assert_sealed "$home/ratchet"
+sealed_identity=$(head -c 9 -- "$home/ratchet/identity")
+[ "$sealed_identity" = "OMAQSEAL1" ] || {
+	echo "history-seal: identity blob not sealed before quarantine" >&2
+	exit 1
+}
+exec 3>&-
+fd_open=0
+kill "$pid" 2>/dev/null || true
+wait "$pid" 2>/dev/null || true
+pid=""
+rm -f "$home/seal.key"
+# The planted transcript has no owning contact; OmaQ already refuses to unlock
+# while an orphan conversation directory exists, which is unrelated to
+# sealing, so drop it before exercising the quarantine.
+rm -rf "$home/history"
+rm -f "$fifo"
+mkfifo "$fifo"
+OMAQ_HOME="$home" OMAQ_STATE="$state" "$bin" >"$out" 2>"$out.err" <"$fifo" &
+pid=$!
+exec 3>"$fifo"
+fd_open=1
+i=0
+while [ "$i" -lt 200 ]; do
+	[ -S "$state/omaq.sock" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$i" -lt 200 ] || { echo "history-seal: helper did not restart" >&2; exit 1; }
+# The identity is passphrase-protected again, so unlocking is what reaches the
+# Ratchet store.
+printf '%s\n' '{"op":"identity.unlock","passphrase":"a strong passphrase","id":"hs-unlock"}' >&3
+i=0
+while [ "$i" -lt 200 ]; do
+	set -- "$home"/ratchet.locked-*
+	[ -d "$1" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+set -- "$home"/ratchet.locked-*
+[ -d "$1" ] || {
+	echo "history-seal: sealed Ratchet state was not quarantined" >&2
+	tail -5 "$out.err" >&2 || true
+	exit 1
+}
+assert_sealed "$1"
+[ -f "$home/direct-state-reinvite.required" ] || {
+	echo "history-seal: quarantine did not require fresh invitations" >&2
 	exit 1
 }
 

--- a/tests/history-seal.sh
+++ b/tests/history-seal.sh
@@ -19,7 +19,7 @@ fd_open=0
 cleanup() {
 	[ "$fd_open" -eq 1 ] && exec 3>&- 2>/dev/null || true
 	[ -n "${pid:-}" ] && kill "$pid" 2>/dev/null || true
-	rm -rf "$home" "$state" "$fifo" "$out" "$out.err"
+	rm -rf "$home" "$state" "$fifo" "$out" "$out.err" "${magic:-}" "${head:-}"
 }
 trap cleanup EXIT HUP INT TERM
 
@@ -44,17 +44,37 @@ while [ "$i" -lt 100 ]; do
 done
 [ "$i" -lt 100 ] || { echo "history-seal: helper did not start" >&2; exit 1; }
 
+# The socket is published before the identity finishes loading; identity
+# operations are refused until it exists.
+i=0
+while [ "$i" -lt 200 ]; do
+	[ -s "$home/tox.save" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$i" -lt 200 ] || { echo "history-seal: identity never loaded" >&2; exit 1; }
+
 # Plant a conversation transcript the way the store does.
 mkdir -p "$home/history/7"
 printf '{"id":"m1","from":"peer","text":"attack at dawn"}\n' >"$home/history/7/messages.jsonl"
 chmod 600 "$home/history/7/messages.jsonl"
+
+# Blob headers are binary, so compare bytes rather than shell strings.
+magic=$(mktemp /tmp/omaq-hsm-XXXXXX)
+head=$(mktemp /tmp/omaq-hsh-XXXXXX)
+printf 'OMAQSEAL1' >"$magic"
+
+is_sealed() {
+	head -c 9 -- "$1" >"$head" 2>/dev/null || return 1
+	cmp -s "$head" "$magic"
+}
 
 # Every regular file under $1 must begin with the seal magic.
 assert_sealed() {
 	found=0
 	for f in $(find "$1" -type f 2>/dev/null); do
 		found=1
-		if [ "$(head -c 9 -- "$f")" != "OMAQSEAL1" ]; then
+		if ! is_sealed "$f"; then
 			echo "history-seal: $f is not sealed" >&2
 			exit 1
 		fi
@@ -64,7 +84,7 @@ assert_sealed() {
 
 assert_plaintext() {
 	for f in $(find "$1" -type f 2>/dev/null); do
-		if [ "$(head -c 9 -- "$f")" = "OMAQSEAL1" ]; then
+		if is_sealed "$f"; then
 			echo "history-seal: $f is still sealed" >&2
 			exit 1
 		fi
@@ -84,7 +104,7 @@ wait_for() {
 }
 
 printf '%s\n' '{"op":"identity.protect","passphrase":"a strong passphrase","id":"hs-protect"}' >&3
-wait_for '"request":"hs-protect"'
+wait_for '"op":"protect","request":"hs-protect","protected":true'
 
 [ -f "$home/seal.key" ] || { echo "history-seal: no seal key after protect" >&2; exit 1; }
 mode=$(stat -c %a -- "$home/seal.key")
@@ -110,7 +130,7 @@ fi
 assert_sealed "$home/ratchet"
 
 printf '%s\n' '{"op":"identity.unprotect","passphrase":"a strong passphrase","id":"hs-unprotect"}' >&3
-wait_for '"request":"hs-unprotect"'
+wait_for '"op":"unprotect","request":"hs-unprotect","protected":false'
 
 [ -f "$home/seal.key" ] && { echo "history-seal: seal key survived unprotect" >&2; exit 1; }
 grep -a -q "attack at dawn" "$home/history/7/messages.jsonl" || {
@@ -123,10 +143,9 @@ assert_plaintext "$home/ratchet"
 # store must be moved aside and fresh invitations required - never opened as
 # if it were empty.
 printf '%s\n' '{"op":"identity.protect","passphrase":"a strong passphrase","id":"hs-protect2"}' >&3
-wait_for '"request":"hs-protect2"'
+wait_for '"op":"protect","request":"hs-protect2","protected":true'
 assert_sealed "$home/ratchet"
-sealed_identity=$(head -c 9 -- "$home/ratchet/identity")
-[ "$sealed_identity" = "OMAQSEAL1" ] || {
+is_sealed "$home/ratchet/identity" || {
 	echo "history-seal: identity blob not sealed before quarantine" >&2
 	exit 1
 }

--- a/tests/history-seal.sh
+++ b/tests/history-seal.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Setting an identity passphrase must also seal chat history at rest, and
+# removing it must return the history to plaintext. No network required.
+set -eu
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+bin=${1:-$root/helper/omaq}
+[ -x "$bin" ] || { echo "history-seal: missing helper binary" >&2; exit 1; }
+
+real_home="${HOME}/.local/share/omaq"
+home=$(mktemp -d /tmp/omaq-hs-XXXXXX)
+state=$(mktemp -d /tmp/omaq-hss-XXXXXX)
+fifo=$(mktemp -u /tmp/omaq-hsf-XXXXXX)
+out=$(mktemp /tmp/omaq-hso-XXXXXX)
+pid=""
+fd_open=0
+# shellcheck disable=SC2329 # Invoked by the EXIT trap.
+cleanup() {
+	[ "$fd_open" -eq 1 ] && exec 3>&- 2>/dev/null || true
+	[ -n "${pid:-}" ] && kill "$pid" 2>/dev/null || true
+	rm -rf "$home" "$state" "$fifo" "$out" "$out.err"
+}
+trap cleanup EXIT HUP INT TERM
+
+case "$home" in
+"$real_home"|"$real_home"/*)
+	echo "history-seal: refused real home" >&2
+	exit 1
+	;;
+esac
+
+mkfifo "$fifo"
+OMAQ_HOME="$home" OMAQ_STATE="$state" "$bin" >"$out" 2>"$out.err" <"$fifo" &
+pid=$!
+exec 3>"$fifo"
+fd_open=1
+
+i=0
+while [ "$i" -lt 100 ]; do
+	[ -S "$state/omaq.sock" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ "$i" -lt 100 ] || { echo "history-seal: helper did not start" >&2; exit 1; }
+
+# Plant a conversation transcript the way the store does.
+mkdir -p "$home/history/7"
+printf '{"id":"m1","from":"peer","text":"attack at dawn"}\n' >"$home/history/7/messages.jsonl"
+chmod 600 "$home/history/7/messages.jsonl"
+
+wait_for() {
+	i=0
+	while [ "$i" -lt 200 ]; do
+		grep -a -q "$1" "$out" && return 0
+		i=$((i + 1))
+		sleep 0.05
+	done
+	echo "history-seal: timed out waiting for $1" >&2
+	tail -5 "$out.err" >&2 || true
+	exit 1
+}
+
+printf '%s\n' '{"op":"identity.protect","passphrase":"a strong passphrase","id":"hs-protect"}' >&3
+wait_for '"request":"hs-protect"'
+
+[ -f "$home/seal.key" ] || { echo "history-seal: no seal key after protect" >&2; exit 1; }
+mode=$(stat -c %a -- "$home/seal.key")
+[ "$mode" = "600" ] || { echo "history-seal: seal key mode $mode" >&2; exit 1; }
+if grep -a -q "attack at dawn" "$home/history/7/messages.jsonl"; then
+	echo "history-seal: history still plaintext after protect" >&2
+	exit 1
+fi
+grep -a -q '^#1:' "$home/history/7/messages.jsonl" || {
+	echo "history-seal: history not sealed after protect" >&2
+	exit 1
+}
+# The plaintext must not survive anywhere under the home.
+if grep -a -r -q "attack at dawn" "$home" 2>/dev/null; then
+	echo "history-seal: plaintext transcript left on disk" >&2
+	exit 1
+fi
+
+printf '%s\n' '{"op":"identity.unprotect","passphrase":"a strong passphrase","id":"hs-unprotect"}' >&3
+wait_for '"request":"hs-unprotect"'
+
+[ -f "$home/seal.key" ] && { echo "history-seal: seal key survived unprotect" >&2; exit 1; }
+grep -a -q "attack at dawn" "$home/history/7/messages.jsonl" || {
+	echo "history-seal: history not restored after unprotect" >&2
+	exit 1
+}
+
+if ! kill -0 "$pid" 2>/dev/null; then
+	echo "history-seal: helper died" >&2
+	exit 1
+fi
+echo "history-seal: ok"
+exit 0

--- a/tests/omaq_test.c
+++ b/tests/omaq_test.c
@@ -18,6 +18,7 @@
 #include "../helper/ratchet_pin.h"
 #include "../helper/presence.h"
 #include "../helper/receipt.h"
+#include "../helper/seal.h"
 #include "../helper/rate.h"
 #include "../helper/roles.h"
 #include "../helper/safety.h"
@@ -1496,6 +1497,133 @@ static void test_message_rate(void)
 		"g:1000000000000000000000000000000000000000000000000000000000000000",
 		actor, 10000) == 0)
 		fail("message rate global burst limit");
+}
+
+static void test_history_sealing(void)
+{
+	char home[] = "/tmp/omaq-seal-home-XXXXXX";
+	char path[512];
+	char raw[8192];
+	char *tail = NULL;
+	size_t tail_len = 0;
+	omaq_seal_key key;
+	FILE *f;
+	size_t got;
+
+	memset(&key, 0, sizeof(key));
+	if (!omaq_seal_ready()) {
+		fail("seal unavailable");
+		return;
+	}
+	if (!mkdtemp(home)) {
+		fail("seal home");
+		return;
+	}
+
+	/* Without a key the store behaves exactly as before: plaintext JSONL. */
+	if (omaq_store_seal_active())
+		fail("seal active before key");
+	if (omaq_store_append(home, "7", "{\"id\":\"m1\",\"text\":\"legacy\"}") != 0)
+		fail("append plaintext");
+	snprintf(path, sizeof(path), "%s/history/7/messages.jsonl", home);
+	f = fopen(path, "r");
+	if (!f) {
+		fail("history file");
+		return;
+	}
+	got = fread(raw, 1, sizeof(raw) - 1, f);
+	fclose(f);
+	raw[got] = '\0';
+	if (!strstr(raw, "legacy"))
+		fail("plaintext not written");
+
+	/* Installing a key seals new records. */
+	if (omaq_seal_key_create(home, "a strong passphrase", &key) != 0) {
+		fail("seal key create");
+		return;
+	}
+	omaq_store_set_seal_key(&key);
+	if (!omaq_store_seal_active())
+		fail("seal inactive after key");
+	if (omaq_store_append(home, "7", "{\"id\":\"m2\",\"text\":\"secret words\"}") != 0)
+		fail("append sealed");
+	f = fopen(path, "r");
+	if (!f) {
+		fail("history file 2");
+		return;
+	}
+	got = fread(raw, 1, sizeof(raw) - 1, f);
+	fclose(f);
+	raw[got] = '\0';
+	if (strstr(raw, "secret words"))
+		fail("sealed record leaked plaintext");
+	if (!strstr(raw, OMAQ_SEAL_RECORD_PREFIX))
+		fail("sealed record not written");
+	/* Legacy plaintext and sealed records coexist and both read back. */
+	if (omaq_store_tail(home, "7", 10, &tail, &tail_len) != 0 || !tail) {
+		fail("tail mixed");
+	} else {
+		if (!strstr(tail, "legacy") || !strstr(tail, "secret words"))
+			fail("mixed read");
+		free(tail);
+		tail = NULL;
+	}
+
+	/* Migration seals what is left. */
+	if (omaq_store_reseal_all(home) < 0)
+		fail("reseal all");
+	f = fopen(path, "r");
+	if (!f) {
+		fail("history file 3");
+		return;
+	}
+	got = fread(raw, 1, sizeof(raw) - 1, f);
+	fclose(f);
+	raw[got] = '\0';
+	if (strstr(raw, "legacy") || strstr(raw, "secret words"))
+		fail("migration left plaintext");
+	if (omaq_store_tail(home, "7", 10, &tail, &tail_len) != 0 || !tail ||
+	    !strstr(tail, "legacy") || !strstr(tail, "secret words"))
+		fail("read after migration");
+	free(tail);
+	tail = NULL;
+
+	/* Without the key the sealed history is unreadable, never plaintext. */
+	omaq_store_set_seal_key(NULL);
+	if (omaq_store_seal_active())
+		fail("seal active after clear");
+	if (omaq_store_tail(home, "7", 10, &tail, &tail_len) == 0)
+		fail("sealed history readable without key");
+	free(tail);
+	tail = NULL;
+
+	/* The wrong passphrase cannot install a usable key. */
+	{
+		omaq_seal_key wrong;
+
+		memset(&wrong, 0, sizeof(wrong));
+		if (omaq_seal_key_open(home, "not the passphrase", &wrong) != -1)
+			fail("wrong passphrase opened seal key");
+	}
+
+	/* Unsealing restores plaintext for an identity that drops its passphrase. */
+	omaq_store_set_seal_key(&key);
+	if (omaq_store_tail(home, "7", 10, &tail, &tail_len) != 0 || !tail)
+		fail("reopen with key");
+	free(tail);
+	tail = NULL;
+	omaq_store_set_seal_key(NULL);
+	if (omaq_store_reseal_all(home) >= 0)
+		fail("unseal without key succeeded");
+	omaq_seal_key_clear(&key);
+
+	(void)unlink(path);
+	snprintf(path, sizeof(path), "%s/history/7", home);
+	(void)rmdir(path);
+	snprintf(path, sizeof(path), "%s/history", home);
+	(void)rmdir(path);
+	(void)omaq_seal_key_destroy(home);
+	(void)rmdir(home);
 }
 
 static void test_safety(void)
@@ -3282,6 +3410,7 @@ int main(void)
 	test_group_file_offer_rate();
 	test_message_rate();
 	test_safety();
+	test_history_sealing();
 	test_group_file_wire();
 	test_group_invite();
 	test_direct_state();

--- a/tests/qml_plaintext_test.py
+++ b/tests/qml_plaintext_test.py
@@ -19,7 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 QML_POLICY_SHA256 = {
     "CallTone.qml": "12d873ec1b774ed038fb526b0b2b7fd2a1a71e97d9987aa27fef06f6f4d93ddc",
     "ChatSurface.qml": "85c63d92d66aebc53556d178276ab0aa31bb20556548dd3a7727ab4fda320d3f",
-    "Panel.qml": "cc888b37da8de0afc955ed04f0aab40577670edf574fac7ba4d8ba771d6b5d77",
+    "Panel.qml": "5c98c8ca82d2e1147e51ac638b7091535cf14210c5a34aea6a961861a7614e08",
     "PlacementController.qml": "82f72fcee9a6aceeb6d1015095fea4961eb2cddbdc11943ef410e160060df76a",
     "SafeText.qml": "a8bfa2ea5e13cbd50bf7e9c70995bea06ceeaca9c9d61e63b243ce18a830e354",
     "Service.qml": "ffd4171eb4506e6722fcb0747cf99bbf3c4fc341a9877fb20a5c3c1ab7ddf5ec",
@@ -146,7 +146,7 @@ REVIEWED_COMPUTED_IDS = set().union(*COMPUTED_WRITE_ALLOWLIST.values())
 COMPUTED_WRITE_SOURCE_SHA256 = {
     "CallTone.qml": "8d9a0af95e58b888dfd09e37c198684843aa10d306f815abc868b88c61496c86",
     "ChatSurface.qml": "61cb0a3d9aecdecdac9bc1ad1cefa941dd4f3047a0c2bfe336484eded210661d",
-    "Panel.qml": "0bb106d37a920d1cf34d316fc9e08610c868f9d8f4e9863128075eaa27c8fcbc",
+    "Panel.qml": "1f7395f5b426d2c08d81f68cff699d93b385e057ae67e6004e82ecdc883d6127",
     "Service.qml": "2395f4a77de4bc06a4cd21ad77bdd19fe98c9d41b2bd48de7bfb69eb1d383809",
     "pages/ChatPage.qml": "3232198c177017757631b97f59c5f45f7442cd9ca58b3c3972dec81e72c8a076",
 }


### PR DESCRIPTION
Closes #41.

## What this does

Extends the identity passphrase to cover **chat history and the whole Ratchet store, including the Signal identity private key** — the two stores the issue names.

### Key hierarchy

New **`helper/seal.c`** (self-contained, libsodium only — already a transitive dependency via toxcore):

- **Argon2id** (`crypto_pwhash`, parameters stored in the key file so they can change later) derives a wrapping key from the identity passphrase.
- A **random 32-byte data key** is generated once per home and stored wrapped in `$home/seal.key` (mode `0600`, written via `O_EXCL|O_NOFOLLOW` → `fchmod` → `fsync` → atomic `rename` → parent `fsync`, matching the house pattern).
- Deriving once per unlock, not per record, keeps message throughput unaffected.

### What is sealed

**XChaCha20-Poly1305**, with the AEAD associated data binding each item to its location:

- **Chat history** — record-by-record, AAD = the conversation directory, so a record cannot be replayed into another conversation. Append-only semantics and log rotation are preserved; sealed records are a `#1:`-prefixed base64 line, which cannot collide with the JSON the store already writes.
- **Ratchet state** — whole-blob, AAD = the blob name. This covers sessions, signed prekeys, and `ratchet/identity`, i.e. the Signal identity **private** key.

### Lifecycle

- `identity.protect` creates the key and migrates existing data, **atomically per file**, so an interrupted run leaves a readable mix rather than corruption.
- `identity.unprotect` rewrites everything back to plaintext while the key can still read it, then deletes the key.
- `seal.key` was added to the identity-archive table so it travels with `history`/`ratchet` when an identity is replaced.

### Fail-closed at the data boundary

Enforcement is in `read_lines()` and `read_blob()`, not at login: without the key a sealed record or blob is a **hard read error** — never returned as plaintext, never silently reported as empty. Putting the check at login instead was tried and rejected; it locks the user out during legitimate identity-restore transitions.

### The hazard flagged in the issue

Exactly as #41 predicted, a home can hold Ratchet state sealed under a passphrase the current identity no longer carries — an identity restored from a recovery copy that predates the passphrase. Naively failing the open reproducibly breaks `tests/reinvite-recovery.sh`.

`open_ratchet_store()` now wraps **every** Ratchet open. If `omaq_ratchet_sealed_locked()` reports blobs the installed key cannot open, the store is **quarantined**: renamed to `ratchet.locked-<time>-<token>`, `direct-state-reinvite.required` set, then a fresh store opened. Nothing is deleted — the sealed bytes stay recoverable if the passphrase turns up — and this reuses the reinvite-recovery idiom the project already has for archived direct state.

## Drive-by fix

`prepare_identity_archive()` hardcoded `i < 10` as the split between its home and state path tables, so adding **any** entry silently misaligns every later path. It now derives the split from `sizeof(home_names)/sizeof(home_names[0])`. This bit me while adding `seal.key`; it would bite the next person too.

## Tests

- `tests/omaq_test.c` under ASAN/UBSAN — plaintext→sealed transition, absence of the plaintext in the on-disk bytes, mixed legacy/sealed reads in one file, migration, unreadability without the key, wrong-passphrase rejection, and that `reseal_all` refuses to unseal without a key.
- **`tests/history-seal.sh`** (new) drives the **real helper** end to end: `identity.protect` ⇒ `seal.key` at `0600`, transcript sealed, `ratchet/identity` sealed, and `grep -r` finds the plaintext **nowhere** under the home; `identity.unprotect` ⇒ key gone, both stores plaintext again; then key deleted + restart + unlock ⇒ Ratchet store quarantined (still sealed) with `direct-state-reinvite.required` set. Wired into `make test` via `verify-1-offline`. Ran 20/20 green.
- `tests/reinvite-recovery.sh` exercises the quarantine on a real identity-restore flow and passes.

A `check-sodium` gate matches the existing `check-signal`/`check-audio`/`check-images` ladder, so the helper still cannot be built without the crypto it needs.

## Scope note

Avatars, received files, receipts, preferences, and unread state remain covered only by filesystem permissions. `docs/SECURITY.md`, `README.md`, and the identity panel now say precisely what is and is not covered, rather than the previous blanket "does not encrypt … chat history".

## Verification

`make test` passes end-to-end (exit 0) on this branch, on Omarchy/Arch Linux ARM (aarch64), including `no-signal-build: ok` and `omarchy plugin validate .`. Rebased onto current `main` (`4c69438`); reviewed originally at `3cf3751`.

> Note: #39 and #40 touch some of the same files. Each branch is cut independently from `main`; I'll rebase this one after the others merge.

