### PR TITLE
Isolate Phase 6 audio test devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,8 @@ verify-6: test arch helper
 	fi
 	sh tests/lock-elect.sh
 	omarchy plugin validate .
+	sh tests/phase6-audio-server-test.sh
+	sh tests/phase6-audio-orphans-test.sh
 	sh tests/phase6.sh
 	sh tests/encryptsave.sh
 	@echo "verify-6: ok"

--- a/docs/stages/06-media.md
+++ b/docs/stages/06-media.md
@@ -22,7 +22,9 @@
 make verify-6
 ```
 
-`tests/phase6.sh` prints the measured call-peak RSS. The gate is 40,960 kB.
+`tests/phase6.sh` prints the measured call-peak RSS. The gate is 40,960 kB. Its four `OmaQ-Call-Test-*` capture and playback endpoints run on a parent-death-bound private PipeWire/PulseAudio server, so they do not appear in the user's normal device registry.
+
+Before starting the private server, the harness removes only exact `omaq_p6_<pid>_{cap,out}_{a,b}` modules whose owning PID is no longer alive. Two SIGKILL regressions verify private-server teardown and legacy orphan reclamation without removing a live run.
 
 ## Stays out
 

--- a/tests/phase6-audio-orphans-test.sh
+++ b/tests/phase6-audio-orphans-test.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# A Phase 6 start reclaims exact null sinks whose PID owner died by SIGKILL.
+set -eu
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+
+for tool in pactl pipewire python3 wireplumber; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "phase6-audio-orphans-test: SKIP: $tool unavailable"
+		exit 0
+	fi
+done
+
+owner=""
+stale_module=""
+live_module=""
+near_module=""
+pulse_runtime=""
+pulse_server_pid=""
+# shellcheck disable=SC2329 # Invoked by trap.
+cleanup() {
+	[ -n "${owner:-}" ] && kill -KILL "$owner" 2>/dev/null || true
+	[ -n "${owner:-}" ] && wait "$owner" 2>/dev/null || true
+	[ -n "${stale_module:-}" ] && pactl unload-module "$stale_module" 2>/dev/null || true
+	[ -n "${live_module:-}" ] && pactl unload-module "$live_module" 2>/dev/null || true
+	[ -n "${near_module:-}" ] && pactl unload-module "$near_module" 2>/dev/null || true
+	[ -n "${pulse_server_pid:-}" ] && kill "$pulse_server_pid" 2>/dev/null || true
+	[ -n "${pulse_server_pid:-}" ] && wait "$pulse_server_pid" 2>/dev/null || true
+	[ -n "${pulse_runtime:-}" ] && rm -rf "$pulse_runtime"
+}
+trap cleanup EXIT
+
+module_exists() {
+	pactl list short modules | awk -v wanted="$1" '
+		$1 == wanted { found = 1 }
+		END { exit found ? 0 : 1 }
+	'
+}
+
+pulse_runtime=$(mktemp -d /tmp/omaq-p6-orphan-pulse-XXXXXX)
+chmod 700 "$pulse_runtime"
+python3 "$root/tests/phase6-audio-server.py" "$$" "$pulse_runtime" &
+pulse_server_pid=$!
+i=0
+while [ "$i" -lt 100 ]; do
+	[ -S "$pulse_runtime/pulse/native" ] && [ -f "$pulse_runtime/ready" ] && break
+	kill -0 "$pulse_server_pid" 2>/dev/null || break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -S "$pulse_runtime/pulse/native" ] && [ -f "$pulse_runtime/ready" ] || {
+	echo "phase6-audio-orphans-test: private PulseAudio unavailable" >&2
+	exit 1
+}
+PULSE_SERVER="unix:$pulse_runtime/pulse/native"
+export PULSE_SERVER
+pactl info >/dev/null
+
+sleep 300 &
+owner=$!
+stale_sink="omaq_p6_${owner}_cap_a"
+live_sink="omaq_p6_$$_out_b"
+near_sink="omaq_p6_${owner}_cap_c"
+stale_module=$(pactl load-module module-null-sink \
+	sink_name="$stale_sink" \
+	sink_properties=device.description=OmaQ-Call-Orphan-Test)
+live_module=$(pactl load-module module-null-sink \
+	sink_name="$live_sink" \
+	sink_properties=device.description=OmaQ-Call-Live-Test)
+near_module=$(pactl load-module module-null-sink \
+	sink_name="$near_sink" \
+	sink_properties=device.description=OmaQ-Call-Near-Match-Test)
+
+if command -v wpctl >/dev/null 2>&1 &&
+   wpctl status -n 2>/dev/null |
+     grep -F -e "$stale_sink" -e "$live_sink" -e "$near_sink" >/dev/null; then
+	echo "phase6-audio-orphans-test: private test device reached the user server" >&2
+	exit 1
+fi
+
+kill -KILL "$owner"
+wait "$owner" 2>/dev/null || true
+owner=""
+
+sh "$root/tests/phase6-audio-orphans.sh"
+if module_exists "$stale_module"; then
+	echo "phase6-audio-orphans-test: SIGKILL orphan remained" >&2
+	exit 1
+fi
+if ! module_exists "$live_module"; then
+	echo "phase6-audio-orphans-test: live Phase 6 module was removed" >&2
+	exit 1
+fi
+if ! module_exists "$near_module"; then
+	echo "phase6-audio-orphans-test: near-match module was removed" >&2
+	exit 1
+fi
+stale_module=""
+
+echo "phase6-audio-orphans-test: ok"

--- a/tests/phase6-audio-orphans.sh
+++ b/tests/phase6-audio-orphans.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Reclaim PulseAudio null sinks left by dead Phase 6 test owners.
+set -efu
+
+if ! command -v pactl >/dev/null 2>&1; then
+	echo "phase6-audio-orphans: SKIP: pactl unavailable"
+	exit 0
+fi
+
+modules=$(pactl list short modules) || {
+	echo "phase6-audio-orphans: cannot list PulseAudio modules" >&2
+	exit 1
+}
+
+tab=$(printf '\t')
+printf '%s\n' "$modules" |
+while IFS="$tab" read -r module module_name arguments; do
+	[ "$module_name" = "module-null-sink" ] || continue
+	case "$module" in
+	""|*[!0-9]*) continue ;;
+	esac
+
+	sink_name=""
+	for argument in $arguments; do
+		case "$argument" in
+		sink_name=*) sink_name=${argument#sink_name=} ;;
+		esac
+	done
+	case "$sink_name" in
+	omaq_p6_*) ;;
+	*) continue ;;
+	esac
+
+	owner_and_suffix=${sink_name#omaq_p6_}
+	owner=${owner_and_suffix%%_*}
+	suffix=${owner_and_suffix#"$owner"_}
+	case "$owner" in
+	""|*[!0-9]*) continue ;;
+	esac
+	case "$suffix" in
+	cap_a|out_a|cap_b|out_b) ;;
+	*) continue ;;
+	esac
+
+	# A live PID may be the Phase 6 owner or a safely retained PID reuse.
+	# /proc also treats an EPERM result from kill -0 as live.
+	if kill -0 "$owner" 2>/dev/null || [ -d "/proc/$owner" ]; then
+		continue
+	fi
+	if ! pactl unload-module "$module"; then
+		after=$(pactl list short modules) || {
+			echo "phase6-audio-orphans: cannot confirm stale module removal" >&2
+			exit 1
+		}
+		if printf '%s\n' "$after" | awk -v wanted="$module" '
+			$1 == wanted { found = 1 }
+			END { exit found ? 0 : 1 }
+		'; then
+			echo "phase6-audio-orphans: failed to unload stale module $module" >&2
+			exit 1
+		fi
+	fi
+done

--- a/tests/phase6-audio-server-test.sh
+++ b/tests/phase6-audio-server-test.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# The private Phase 6 audio server dies with a SIGKILLed test owner.
+set -eu
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+
+for tool in pactl pipewire python3 wireplumber; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "phase6-audio-server-test: SKIP: $tool unavailable"
+		exit 0
+	fi
+done
+
+unsafe_runtime=""
+runtime=""
+info=""
+owner=""
+server=""
+server_children=""
+# shellcheck disable=SC2329 # Invoked by trap.
+cleanup() {
+	[ -n "${unsafe_runtime:-}" ] && rm -rf "$unsafe_runtime"
+	[ -n "${owner:-}" ] && kill -KILL "$owner" 2>/dev/null || true
+	[ -n "${owner:-}" ] && wait "$owner" 2>/dev/null || true
+	[ -n "${server:-}" ] && kill -TERM "$server" 2>/dev/null || true
+	[ -n "${runtime:-}" ] && rm -rf "$runtime"
+	[ -n "${info:-}" ] && rm -f "$info"
+}
+trap cleanup EXIT
+
+unsafe_runtime=$(mktemp -d /tmp/omaq-p6-unsafe-runtime-XXXXXX)
+printf 'retain\n' >"$unsafe_runtime/sentinel"
+if python3 "$root/tests/phase6-audio-server.py" "$$" "$unsafe_runtime" \
+	>/dev/null 2>&1; then
+	echo "phase6-audio-server-test: unsafe runtime path was accepted" >&2
+	exit 1
+fi
+[ -f "$unsafe_runtime/sentinel" ] || {
+	echo "phase6-audio-server-test: unsafe runtime path was modified" >&2
+	exit 1
+}
+rm -rf "$unsafe_runtime"
+unsafe_runtime=""
+
+runtime=$(mktemp -d /tmp/omaq-p6-server-test-XXXXXX)
+info=$(mktemp /tmp/omaq-p6-server-test-info-XXXXXX)
+chmod 700 "$runtime"
+
+/bin/sh -c '
+	python3 "$1/tests/phase6-audio-server.py" "$$" "$2" &
+	child=$!
+	printf "%s %s\n" "$$" "$child" >"$3"
+	wait "$child"
+' sh "$root" "$runtime" "$info" &
+owner=$!
+
+i=0
+while [ "$i" -lt 100 ]; do
+	[ -s "$info" ] && [ -S "$runtime/pulse/native" ] &&
+		[ -f "$runtime/ready" ] && break
+	kill -0 "$owner" 2>/dev/null || break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -s "$info" ] && [ -S "$runtime/pulse/native" ] &&
+	[ -f "$runtime/ready" ] || {
+	echo "phase6-audio-server-test: private server unavailable" >&2
+	exit 1
+}
+read -r recorded_owner server <"$info"
+[ "$recorded_owner" = "$owner" ] || {
+	echo "phase6-audio-server-test: owner PID binding changed" >&2
+	exit 1
+}
+server_children=$(cat "/proc/$server/task/$server/children")
+[ -n "$server_children" ] || {
+	echo "phase6-audio-server-test: private server children are missing" >&2
+	exit 1
+}
+
+sink="omaq_p6_${owner}_cap_a"
+PULSE_SERVER="unix:$runtime/pulse/native" pactl info >/dev/null
+PULSE_SERVER="unix:$runtime/pulse/native" pactl load-module module-null-sink \
+	sink_name="$sink" \
+	sink_properties=device.description=OmaQ-Call-Test-Isolation >/dev/null
+if pactl list short sinks | grep -F "$sink" >/dev/null ||
+   { command -v wpctl >/dev/null 2>&1 &&
+     wpctl status -n 2>/dev/null | grep -F "$sink" >/dev/null; }; then
+	echo "phase6-audio-server-test: private sink reached the user registry" >&2
+	exit 1
+fi
+
+kill -KILL "$owner"
+wait "$owner" 2>/dev/null || true
+owner=""
+i=0
+while [ "$i" -lt 100 ]; do
+	[ ! -d "/proc/$server" ] && [ ! -e "$runtime" ] && break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ ! -d "/proc/$server" ] && [ ! -e "$runtime" ] || {
+	echo "phase6-audio-server-test: private server survived owner SIGKILL" >&2
+	exit 1
+}
+for child in $server_children; do
+	[ ! -d "/proc/$child" ] || {
+		echo "phase6-audio-server-test: private audio child survived owner SIGKILL" >&2
+		exit 1
+	}
+done
+server=""
+
+echo "phase6-audio-server-test: ok"

--- a/tests/phase6-audio-server.py
+++ b/tests/phase6-audio-server.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Run an isolated PipeWire/PulseAudio server bound to the parent test."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import time
+
+PR_SET_PDEATHSIG = 1
+CONFIG_PATH = Path("/usr/share/pipewire/minimal.conf")
+MAX_CONFIG_BYTES = 262_144
+
+
+def fail(message: str) -> "NoReturn":
+    raise SystemExit(f"phase6-audio-server: {message}")
+
+
+def configure_parent_death(expected_parent: int) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        fail(f"prctl(PR_SET_PDEATHSIG) failed: {os.strerror(error)}")
+    if os.getppid() != expected_parent:
+        fail("parent exited before the death signal was armed")
+
+
+def validate_runtime(path: Path) -> tuple[int, int]:
+    prefixes = (
+        "omaq-p6-pulse-",
+        "omaq-p6-orphan-pulse-",
+        "omaq-p6-server-test-",
+    )
+    if path.parent != Path("/tmp") or not any(
+        path.name.startswith(prefix) and path.name[len(prefix):].isalnum()
+        for prefix in prefixes
+    ):
+        fail("runtime path is outside the dedicated /tmp namespace")
+    try:
+        info = path.lstat()
+    except OSError as error:
+        fail(f"cannot inspect runtime directory: {error}")
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid():
+        fail("runtime path is not an owned directory")
+    if stat.S_IMODE(info.st_mode) != 0o700:
+        fail("runtime directory mode is not 0700")
+    return info.st_dev, info.st_ino
+
+
+def remove_runtime(path: Path, identity: tuple[int, int]) -> None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+    if not stat.S_ISDIR(info.st_mode) or (info.st_dev, info.st_ino) != identity:
+        return
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def system_executable(name: str) -> str:
+    path = Path("/usr/bin") / name
+    try:
+        info = path.lstat()
+    except OSError as error:
+        fail(f"cannot inspect {path}: {error}")
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != 0
+        or stat.S_IMODE(info.st_mode) & 0o022
+        or not os.access(path, os.X_OK)
+    ):
+        fail(f"{path} is not a trusted executable")
+    return str(path)
+
+
+def private_config(owner: int) -> bytes:
+    try:
+        info = CONFIG_PATH.lstat()
+    except OSError as error:
+        fail(f"cannot inspect {CONFIG_PATH}: {error}")
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != 0
+        or stat.S_IMODE(info.st_mode) & 0o022
+    ):
+        fail("PipeWire minimal config is not a trusted regular file")
+    if info.st_size <= 0 or info.st_size > MAX_CONFIG_BYTES:
+        fail("PipeWire minimal config size is outside the accepted bound")
+    try:
+        source = CONFIG_PATH.read_text(encoding="utf-8", errors="strict")
+    except (OSError, UnicodeError) as error:
+        fail(f"cannot read PipeWire minimal config: {error}")
+
+    jack = "minimal.use-jack-tunnel = true"
+    if source.count(jack) != 2:
+        fail("PipeWire minimal config has an unexpected jack-tunnel shape")
+    source = source.replace(jack, "minimal.use-jack-tunnel = false", 1)
+
+    objects_start = source.find("context.objects = [")
+    exec_start = source.find("context.exec = [", objects_start)
+    if objects_start < 0 or exec_start < 0:
+        fail("PipeWire minimal config has no bounded context.objects section")
+    private_objects = """context.objects = [
+    { factory = spa-node-factory
+        args = {
+            factory.name = support.node.driver
+            node.name = OmaQ-Test-Dummy-Driver
+            node.group = pipewire.omaq-test
+            priority.driver = 20000
+        }
+    }
+    { factory = spa-node-factory
+        args = {
+            factory.name = support.node.driver
+            node.name = OmaQ-Test-Freewheel-Driver
+            priority.driver = 19000
+            node.group = pipewire.omaq-test-freewheel
+            node.freewheel = true
+        }
+    }
+]
+
+"""
+    source = source[:objects_start] + private_objects + source[exec_start:]
+
+    pulse_marker = '    server.address = [\n        "unix:native"\n    ]\n}'
+    if source.count(pulse_marker) != 1:
+        fail("PipeWire minimal config has an unexpected PulseAudio address")
+    pulse_config = (
+        '    server.address = [\n        "unix:native"\n    ]\n'
+        f'    server.dbus-name = "org.pulseaudio.Server.OmaQTest{owner}"\n'
+        "}"
+    )
+    return source.replace(pulse_marker, pulse_config, 1).encode("utf-8")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        fail("usage: phase6-audio-server.py OWNER_PID RUNTIME_DIR")
+    try:
+        owner = int(sys.argv[1], 10)
+    except ValueError:
+        fail("owner PID is invalid")
+    if owner <= 1:
+        fail("owner PID is outside the accepted range")
+    runtime = Path(sys.argv[2])
+    if not runtime.is_absolute():
+        fail("runtime path must be absolute")
+
+    configure_parent_death(owner)
+    runtime_identity = validate_runtime(runtime)
+    config_path = runtime / "pipewire.conf"
+    config_path.write_bytes(private_config(owner))
+    config_path.chmod(0o600)
+
+    pipewire = system_executable("pipewire")
+    wireplumber = system_executable("wireplumber")
+    environment = os.environ.copy()
+    private_directories = {
+        "HOME": runtime / "home",
+        "XDG_CACHE_HOME": runtime / "cache",
+        "XDG_CONFIG_HOME": runtime / "config",
+        "XDG_STATE_HOME": runtime / "state",
+    }
+    for directory in private_directories.values():
+        directory.mkdir(mode=0o700)
+    environment.update({key: str(path) for key, path in private_directories.items()})
+    environment["PIPEWIRE_RUNTIME_DIR"] = str(runtime)
+    environment["XDG_RUNTIME_DIR"] = str(runtime)
+    stderr_path = runtime / "pipewire.err"
+    stderr_stream = stderr_path.open("w+b", buffering=0)
+    stderr_path.chmod(0o600)
+
+    supervisor_pid = os.getpid()
+
+    def arm_child_parent_death() -> None:
+        libc = ctypes.CDLL(None, use_errno=True)
+        if libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0) != 0:
+            os._exit(125)
+        if os.getppid() != supervisor_pid:
+            os._exit(125)
+
+    stopping = False
+
+    def stop(_signum: int, _frame: object) -> None:
+        nonlocal stopping
+        stopping = True
+
+    def terminate(process: subprocess.Popen[bytes] | None) -> None:
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+    def error_tail() -> str:
+        size = os.fstat(stderr_stream.fileno()).st_size
+        stderr_stream.seek(max(0, size - 2048))
+        return stderr_stream.read(2048).decode("utf-8", errors="replace").strip()
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGHUP, stop)
+    pipewire_process: subprocess.Popen[bytes] | None = None
+    policy_process: subprocess.Popen[bytes] | None = None
+
+    try:
+        pipewire_process = subprocess.Popen(
+            [pipewire, "-c", str(config_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_stream,
+            env=environment,
+            preexec_fn=arm_child_parent_death,
+        )
+        deadline = time.monotonic() + 5
+        native_socket = runtime / "pipewire-0"
+        pulse_socket = runtime / "pulse" / "native"
+        while not stopping and time.monotonic() < deadline:
+            if pipewire_process.poll() is not None:
+                fail(f"private PipeWire exited early: {error_tail()}")
+            if native_socket.is_socket() and pulse_socket.is_socket():
+                break
+            time.sleep(0.05)
+        else:
+            if not stopping:
+                fail("private PipeWire sockets did not become ready")
+        if stopping:
+            return 0
+
+        policy_process = subprocess.Popen(
+            [wireplumber, "--profile", "policy"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_stream,
+            env=environment,
+            preexec_fn=arm_child_parent_death,
+        )
+        time.sleep(0.2)
+        if policy_process.poll() is not None:
+            fail(f"private WirePlumber policy exited early: {error_tail()}")
+        ready_path = runtime / "ready"
+        ready_path.write_text("ready\n", encoding="ascii")
+        ready_path.chmod(0o600)
+
+        while not stopping:
+            if pipewire_process.poll() is not None:
+                fail(f"private PipeWire exited early: {error_tail()}")
+            if policy_process.poll() is not None:
+                fail(f"private WirePlumber policy exited early: {error_tail()}")
+            time.sleep(0.05)
+    finally:
+        terminate(policy_process)
+        terminate(pipewire_process)
+        stderr_stream.close()
+        remove_runtime(runtime, runtime_identity)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/phase6.sh
+++ b/tests/phase6.sh
@@ -32,6 +32,8 @@ call_bridge_b=""
 lease_a_pid=""
 lease_b_pid=""
 pulse_modules=""
+pulse_server_pid=""
+pulse_runtime=""
 pulse_tag="omaq_p6_$$"
 cap_a="${pulse_tag}_cap_a"
 out_a="${pulse_tag}_out_a"
@@ -50,9 +52,12 @@ cleanup() {
 	for module in $pulse_modules; do
 		pactl unload-module "$module" 2>/dev/null || true
 	done
+	[ -n "${pulse_server_pid:-}" ] && kill "$pulse_server_pid" 2>/dev/null || true
+	[ -n "${pulse_server_pid:-}" ] && wait "$pulse_server_pid" 2>/dev/null || true
 	rm -rf "$ha" "$sa" "$hb" "$sb" "$hc" "$sc" "$fa" "$fb" "$fc" \
 		"$src" "$holda" "$holdb" "$holdc" "$calla" "$callb" \
 		"$audio_a" "$audio_b" "$call_replay" "$fa.err" "$fb.err" "$fc.err"
+	[ -n "${pulse_runtime:-}" ] && rm -rf "$pulse_runtime"
 }
 trap cleanup EXIT
 
@@ -128,15 +133,43 @@ esac
 
 printf 'omaq-file-probe\n' >"$src"
 
-for tool in pactl pacat parec python3; do
+for tool in pactl pacat parec pipewire python3 wireplumber; do
 	command -v "$tool" >/dev/null 2>&1 || {
 		echo "phase6: missing audio test tool: $tool" >&2
 		exit 1
 	}
 done
-for sink in "$cap_a" "$out_a" "$cap_b" "$out_b"; do
+# Reclaim only historical system-server modules from dead Phase 6 owners,
+# then keep this run's audio graph outside the user's normal device registry.
+sh "$root/tests/phase6-audio-orphans.sh"
+pulse_runtime=$(mktemp -d /tmp/omaq-p6-pulse-XXXXXX)
+chmod 700 "$pulse_runtime"
+python3 "$root/tests/phase6-audio-server.py" "$$" "$pulse_runtime" &
+pulse_server_pid=$!
+i=0
+while [ "$i" -lt 100 ]; do
+	[ -S "$pulse_runtime/pulse/native" ] && [ -f "$pulse_runtime/ready" ] && break
+	kill -0 "$pulse_server_pid" 2>/dev/null || break
+	i=$((i + 1))
+	sleep 0.05
+done
+[ -S "$pulse_runtime/pulse/native" ] && [ -f "$pulse_runtime/ready" ] || {
+	echo "phase6: private PulseAudio server unavailable" >&2
+	exit 1
+}
+PULSE_SERVER="unix:$pulse_runtime/pulse/native"
+export PULSE_SERVER
+pactl info >/dev/null
+for sink_spec in \
+	"$cap_a:OmaQ-Call-Test-A-Capture" \
+	"$out_a:OmaQ-Call-Test-A-Output" \
+	"$cap_b:OmaQ-Call-Test-B-Capture" \
+	"$out_b:OmaQ-Call-Test-B-Output"
+do
+	sink=${sink_spec%%:*}
+	description=${sink_spec#*:}
 	module=$(pactl load-module module-null-sink sink_name="$sink" \
-		sink_properties=device.description=OmaQPhase6)
+		"sink_properties=device.description=$description")
 	pulse_modules="$module $pulse_modules"
 done
 


### PR DESCRIPTION
## Summary

- run the Phase 6 call endpoints on a parent-death-bound private PipeWire/PulseAudio server so they do not appear in the user's normal audio-device registry
- reclaim only legacy `module-null-sink` modules with exact dead-owner names while retaining live owners and near matches
- add `verify-6` SIGKILL regressions for private-server teardown, global invisibility, strict runtime paths, and legacy orphan cleanup

## Validation

- `make verify-6` — passed (`phase6: ok`, call RSS remained below the 40,960 kB gate)
- ShellCheck and `sh -n` for all changed shell scripts — passed
- `python3 -m py_compile tests/phase6-audio-server.py` — passed
- focused private-server and orphan-cleanup regressions — passed
- post-run checks found no OmaQ test modules, sinks, sources, WirePlumber nodes, supervisors, or private runtimes

## Validation gaps

- the independent code-review agent was unavailable because its local runner could not be spawned
- the existing `qmllint Panel.qml` check remains inconclusive with exit 255 and no diagnostics; this change does not modify QML
- automated coverage does not replace separate native Wayland, multi-monitor, or device acceptance
