### PR TITLE
Prepare v0.9.0-beta.1 prerelease

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Report reproducible incorrect behavior in OmaQ
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve OmaQ. Search existing issues first and remove private identities, contacts, messages, invitation links, safety codes, and machine-specific secrets from everything you submit.
+
+  - type: input
+    id: version
+    attributes:
+      label: OmaQ version or commit
+      description: Find the version in manifest.json. Add the commit when testing an unreleased build.
+      placeholder: "0.9.0-beta.1 or commit SHA"
+    validations:
+      required: true
+
+  - type: input
+    id: omarchy-version
+    attributes:
+      label: Omarchy version
+      placeholder: "Version or commit, if known"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Panel or navigation
+        - Direct chat
+        - Group chat
+        - Calls or audio
+        - Files or images
+        - Identity or invitations
+        - Notifications or appearance
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the incorrect behavior and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open …
+        2. Select …
+        3. Observe …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Relevant diagnostics
+      description: Add sanitized logs, screenshots, or error text. Do not upload private communication data or live invitation material.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues for this problem.
+          required: true
+        - label: I removed private and machine-specific secrets from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/HANCORE-linux/OmaQ/security/advisories/new
+    about: Report vulnerabilities privately. Do not include security details in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Suggest a focused improvement to OmaQ
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem before the proposed implementation. Do not include private identities, contacts, messages, invitation links, safety codes, or machine-specific secrets.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Who encounters this problem, and what can they not do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed improvement
+      description: Describe the desired behavior and user experience.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or simpler alternatives.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary area
+      options:
+        - Panel or navigation
+        - Direct chat
+        - Group chat
+        - Calls or audio
+        - Files or images
+        - Identity or invitations
+        - Installation or updates
+        - Notifications or appearance
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: security
+    attributes:
+      label: Privacy or security considerations
+      description: Explain any effect on local data, identity verification, transport, permissions, or external services.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues for a similar request.
+          required: true
+        - label: This is not a vulnerability report. Security issues must use the private advisory link.
+          required: true

--- a/.github/ISSUE_TEMPLATE/lifecycle-problem.yml
+++ b/.github/ISSUE_TEMPLATE/lifecycle-problem.yml
@@ -1,0 +1,80 @@
+name: Install, update, or uninstall problem
+description: Report a problem with OmaQ's supported lifecycle commands
+title: "[Lifecycle] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form only for installation, update, or removal problems. Remove usernames, local paths, private repository credentials, invitation links, and other secrets from logs before submitting them.
+
+  - type: dropdown
+    id: operation
+    attributes:
+      label: Operation
+      options:
+        - Install
+        - Update
+        - Uninstall
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: OmaQ version or commit
+      placeholder: "0.9.0-beta.1 or commit SHA"
+    validations:
+      required: true
+
+  - type: input
+    id: omarchy-version
+    attributes:
+      label: Omarchy version
+      placeholder: "Version or commit, if known"
+    validations:
+      required: false
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command used
+      description: Paste the exact supported command after removing private values.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: result
+    attributes:
+      label: What happened?
+      description: Include the exit status and the first relevant error.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Sanitized output
+      description: Add only the relevant output. Do not include credentials, private identities, contacts, messages, or invitation data.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I used the supported OmaQ command documented for this operation.
+          required: true
+        - label: I searched existing issues for this problem.
+          required: true
+        - label: I removed private and machine-specific secrets from this report.
+          required: true

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ OmaQ runs no servers and has no operator access to your identity, contacts, or m
 
 Use OmaQ only for lawful private communication with people you trust.
 
+## Project independence and lawful use
+
+OmaQ is general-purpose software intended for lawful use. This policy adds no restrictions to the open-source licenses.
+
+The project responds truthfully to lawful requests from public authorities. If the project does not possess the requested user data, it says so. OmaQ operates no service and cannot provide data stored only on users' devices, including identities, contacts, messages, and history.
+
+The project does not cooperate with resellers. It offers no reseller, original equipment manufacturer (OEM), white-label, or exclusive distribution arrangements. This policy does not limit open-source redistribution rights or imply project affiliation or endorsement.
+
+OmaQ maintains one public codebase. The project offers no private, privileged, selectively weakened, or organization-specific builds, including builds for public authorities, companies, or resellers. Security-relevant changes remain public and reviewable.
+
 ## How OmaQ works
 
 <p align="center">
@@ -61,7 +71,13 @@ omarchy plugin add https://github.com/HANCORE-linux/OmaQ.git --yes &&
 ~/.config/omarchy/plugins/hancore.omaq/install.sh --yes
 ```
 
-Omarchy installs the plugin checkout. `install.sh` installs the required packages, builds the helper, enables OmaQ in its manifest's right bar section, and waits for reactive plugin activation and any in-flight watched-tree reload to expose working OmaQ IPC and a matching running helper. It does not force a second shell restart while asynchronous plugin loaders may still be finalizing. Pass `--section left` or `--section center` to `install.sh` to choose another section.
+`install.sh` installs dependencies, builds the helper, and enables OmaQ in the selected bar section. It waits for verified IPC and helper readiness without forcing another restart. Pass `--section left` or `--section center` to change the section.
+
+If a successful install reports a current helper but OmaQ is still absent, refresh the shell:
+
+```bash
+omarchy restart shell
+```
 
 ## Update
 
@@ -71,9 +87,15 @@ Run the shell-off updater from the installed Git checkout:
 ~/.config/omarchy/plugins/hancore.omaq/scripts/update-omaq.sh --yes
 ```
 
-Do not update OmaQ with `omarchy plugin update`, including the all-plugins form. Omarchy would fast-forward the source checkout without rebuilding its native helper. Always use the OmaQ updater above.
+Do not update OmaQ with `omarchy plugin update`, including the all-plugins form. It updates the checkout without rebuilding the native helper.
 
-When needed, the updater builds outside the monitored plugin tree, exchanges the checkout while the shell is stopped, and verifies the result. Active groups can defer helper activation. See the [installation lifecycle](docs/INSTALLATION.md) for older installations, exact-commit pinning, backups, and recovery.
+When needed, the updater builds outside the monitored plugin tree. It exchanges the checkout while the shell is stopped and verifies the result. Active groups can defer helper activation. See the [installation lifecycle](docs/INSTALLATION.md) for older installations, exact-commit pinning, backups, and recovery.
+
+After an `activated` or `current` result, refresh the shell only if the interface has not reappeared:
+
+```bash
+omarchy restart shell
+```
 
 ## Uninstall
 
@@ -83,7 +105,7 @@ Run the verified wrapper:
 ~/.config/omarchy/plugins/hancore.omaq/scripts/uninstall-omaq.sh
 ```
 
-Keep retained data if you may reinstall OmaQ or still need the identity or history. In an interactive run, every remaining OmaQ data directory is offered separately for permanent removal; each answer defaults to No. `--yes` removes the plugin non-interactively and retains all data. Dependency packages are never removed automatically; the wrapper prints a separate non-recursive Pacman command for optional manual cleanup.
+Interactive mode offers every remaining OmaQ data directory separately and defaults each answer to No. `--yes` retains all data. Dependency packages are never removed automatically. The wrapper only prints a non-recursive Pacman command for optional manual cleanup.
 
 ## Documentation
 

--- a/docs/CURRENT.md
+++ b/docs/CURRENT.md
@@ -1,4 +1,4 @@
-# Current status: 2026-09-05
+# Current status: 2026-09-06
 
 This page is the current product and release snapshot. Completed phase and follow-up history lives in the [stage notes](stages/README.md).
 
@@ -6,7 +6,7 @@ This page is the current product and release snapshot. Completed phase and follo
 
 - **Project:** OmaQ, plugin id `hancore.omaq`
 - **Branch:** `main`
-- **Manifest version:** `0.8.1-beta.2`, Protocol 16
+- **Manifest version:** `0.9.0-beta.1`, Protocol 16
 - **AUR:** paused; no registration or upload
 - **Documentation:** the task-based [documentation index](README.md) links the illustrated guide, security model, installation lifecycle, and historical notes
 
@@ -51,7 +51,11 @@ The Protocol 16 direct-invite snapshot passes the full `make verify-4` gate, Pro
 
 The release-audit follow-up passes the full `make test` aggregate, `make verify-4`, `make helper`, `make arch`, phase 2, phase 8, Omarchy plugin validation, ShellCheck on every changed shell file, Qt parsing for all eight QML files, `qmllint` for ChatSurface, ChatPage, and Service, syntax checks, and `git diff --check`. The normal-plugin lifecycle change additionally passes the full `make test` aggregate, `make arch`, Omarchy plugin validation, focused install and uninstall regressions, ShellCheck, Python syntax compilation, and `git diff --check`. Panel runtime coverage verifies both semantic Omarchy theme keys and legacy `color0`–`color7` palettes, including deterministic legacy precedence in a mixed file.
 
-Repeated phase 2 runs measured 13.2 to 15.2 MB helper RSS against the documented absolute 51,200 kB limit. Repeated phase 6 runs passed file, timestamp, call, and public-network diagnostics with 30 to 32 MB call RSS. Protocol-15 phase 6 coverage also exercises request-correlated hangup, failed-action and stop-terminal replay, helper live-owner metadata during a same-socket status handshake, identity-mutation refusal during teardown, complete local media stop, ToxAV transport replacement, controlling-socket loss, lease expiry, and silence after each confirmed stop. These tests use isolated PulseAudio null sinks and do not replace live microphone, speaker, or network acceptance. Attachment checks wait for sender and receiver events plus both local history entries, then compare each event only with its matching local history timestamp.
+Repeated phase 2 runs measured 13.2 to 15.2 MB helper RSS against the documented absolute 51,200 kB limit. Repeated phase 6 runs passed file, timestamp, call, and public-network diagnostics with 30 to 32 MB call RSS. Protocol-15 phase 6 coverage also exercises request-correlated hangup, failed-action and stop-terminal replay, helper live-owner metadata during a same-socket status handshake, identity-mutation refusal during teardown, complete local media stop, ToxAV transport replacement, controlling-socket loss, lease expiry, and silence after each confirmed stop.
+
+The Phase 6 tests use null sinks on a parent-death-bound private PipeWire/PulseAudio server outside the normal user device registry. SIGKILL regressions verify private-server teardown and exact cleanup of legacy Phase 6 orphans while retaining live owners and near matches.
+
+The audio tests do not replace live microphone, speaker, or network acceptance. Attachment checks wait for sender and receiver events plus both local history entries, then compare each event only with its matching local history timestamp.
 
 Uninstall regressions cover current and byte-identical relocated helper inodes, changed relocated bytes, current and legacy rule names, interrupted temporary names, symlink and hardlink entries, unsafe root and rule-directory modes, unexpected files, individually declined data, confirmed data deletion, nested Yes/No and protected-path conflicts, writable-tree and mount-boundary refusal, configured external download paths, and the manual non-recursive package command. Update regressions cover source no-ops without a shell stop, private credential-free network homes and `.netrc` exclusion on remote resolution, monitored-path refusal, bounded external staging and descendant cleanup, complete Git checkout identity, literal root-level protocol compatibility, pre-stop exchange probing, delayed shell readiness, supervisor backoff and reappearance during rollback, restarted-shell identity, restart injection before exchange, same-filesystem atomic exchange, cross-device refusal, no copy fallback, reversible rollback, post-activation helper hashes and protocol, and an unchanged `.prev` during activation. Installation regressions cover the normal disabled Omarchy acquisition command, live validation, package/build/enable/readiness fail-stop ordering, delayed plugin IPC, readiness timeout without a forced restart, helper readiness, root entry-point arguments, Bash and Fish command parity, the external atomic no-replace path, exact enable-response loss, and bounded retries only for the exact observed shell-IPC transition tuple.
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "hancore.omaq",
   "name": "OmaQ",
-  "version": "0.8.1-beta.2",
+  "version": "0.9.0-beta.1",
   "author": "hancore",
   "license": "MIT AND GPL-3.0-only AND CC-BY-SA-4.0 AND CC0-1.0 AND OFL-1.1-no-RFN AND LicenseRef-Pixabay-Content",
   "description": "Invite-only 1:1 and group chat for the Omarchy bar.",

--- a/tests/update-order.sh
+++ b/tests/update-order.sh
@@ -450,6 +450,19 @@ if ! grep -Fq 'Do not update OmaQ with' "$root/README.md" ||
   echo "update-order: README generic-updater warning changed" >&2
   exit 1
 fi
+[ "$(grep -Fc 'omarchy restart shell' "$root/README.md")" -eq 2 ] || {
+  echo "update-order: README shell-refresh hints changed" >&2
+  exit 1
+}
+grep -Fq 'If a successful install reports a current helper but OmaQ is still absent' \
+  "$root/README.md" || {
+  echo "update-order: install shell-refresh hint is not readiness-gated" >&2
+  exit 1
+}
+grep -Fq "After an \`activated\` or \`current\` result" "$root/README.md" || {
+  echo "update-order: update shell-refresh hint is not result-gated" >&2
+  exit 1
+}
 if ! grep -Fq 'include OmaQ in an all-plugins' "$root/docs/INSTALLATION.md" ||
     ! grep -Fq 'omarchy plugin update --yes' "$root/docs/INSTALLATION.md"; then
   echo "update-order: installation guide omits the all-plugins update risk" >&2


### PR DESCRIPTION
## Summary

- set the manifest and current snapshot to `v0.9.0-beta.1` with Protocol 16
- shorten the supported install, update, and uninstall guidance and limit shell-refresh advice to successful readiness states
- publish the non-license-restricting lawful-use and project-independence policy
- add focused bug, lifecycle, and feature forms, disable blank issues, and route vulnerabilities to private GitHub Security Advisories

## Validation

- `make test` — passed
- `make verify-4` — passed, including Omarchy plugin validation
- `tests/update-order.sh` — passed
- ShellCheck and `sh -n` for the changed shell regression — passed
- strict JSON and YAML parsing, duplicate-key rejection, issue-form structure, category count, private security link, and secret-pattern checks — passed
- `git diff --check` — passed

## Validation gaps

- the independent code-review agent was unavailable because its local runner could not be spawned
- the existing `qmllint Panel.qml` check remains inconclusive with exit 255 and no diagnostics; this PR does not modify QML
- automated coverage does not replace native Wayland, multi-monitor, real audio-device, separate-network, or complete three-peer acceptance

## Release boundary

Merging this PR does not create a tag or GitHub release. `v0.9.0-beta.1` remains planned as a prerelease, and packaging and AUR publication remain paused.
