### PR TITLE
Sync chat history before reporting append success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tests/omaq_test
+tests/store_append_test
 tests/stdout_spool_test
 tests/file_transfer_test
 tests/av_state_test

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ TEST_SRC := tests/omaq_test.c helper/invite.c helper/roles.c helper/conversation
 	helper/direct_state.c helper/ratchet.c helper/ratchet_pin.c
 
 BIN_TEST := tests/omaq_test
+BIN_STORE_APPEND_TEST := tests/store_append_test
 BIN_SPOOL_TEST := tests/stdout_spool_test
 BIN_FILE_TRANSFER_TEST := tests/file_transfer_test
 BIN_AV_STATE_TEST := tests/av_state_test
@@ -95,6 +96,13 @@ all: $(BIN_TEST) helper
 
 $(BIN_TEST): $(TEST_SRC)
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) $(AVATAR_CFLAGS) -o $@ $(TEST_SRC) $(AVATAR_LIBS)
+
+$(BIN_STORE_APPEND_TEST): tests/store_append_test.c helper/store.c helper/store.h helper/json_io.c helper/conversation.c helper/text.c
+	# Keep fprintf interposable for write-error injection in this test only.
+	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) \
+		-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -fno-builtin-fprintf -o $@ \
+		tests/store_append_test.c helper/store.c helper/json_io.c helper/conversation.c helper/text.c \
+		-Wl,--wrap=fprintf,--wrap=fflush,--wrap=fsync,--wrap=fclose
 
 $(BIN_SPOOL_TEST): tests/stdout_spool_test.c helper/stdout_spool.c helper/stdout_spool.h
 	$(CC) -std=c11 -Wall -Werror -O1 $(SANFLAGS) -DOMAQ_STDOUT_SPOOL_MAX=5242880u \
@@ -192,8 +200,9 @@ $(BIN_HELP): check-signal check-audio check-images $(HELPER_SRC)
 	$(CC) $(CFLAGS) $(HARDEN_CFLAGS) $(HARDEN_LDFLAGS) -o $@ $(HELPER_SRC) $(TOX_LIBS)
 
 # Keep native Quickshell and Omarchy shell fixtures in the local test target.
-test-ci: check-tox check-signal check-audio check-images check-node check-qml $(BIN_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TEST) $(SIGNAL_TEST_TARGET) $(IDENTITY_GUARD_TEST_TARGET) $(TOX_RELAY_RETRY_TEST_TARGET) $(TOX_NAME_TEST_TARGET) $(BIN_IPC_TEST_HELPER) $(BIN_HELP)
+test-ci: check-tox check-signal check-audio check-images check-node check-qml $(BIN_TEST) $(BIN_STORE_APPEND_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TEST) $(SIGNAL_TEST_TARGET) $(IDENTITY_GUARD_TEST_TARGET) $(TOX_RELAY_RETRY_TEST_TARGET) $(TOX_NAME_TEST_TARGET) $(BIN_IPC_TEST_HELPER) $(BIN_HELP)
 	./$(BIN_TEST)
+	./$(BIN_STORE_APPEND_TEST)
 	./$(BIN_SPOOL_TEST)
 	./$(BIN_FILE_TRANSFER_TEST)
 	./$(BIN_AV_STATE_TEST)
@@ -226,8 +235,9 @@ test-ci: check-tox check-signal check-audio check-images check-node check-qml $(
 	python3 tests/ipc-regression.py ./$(BIN_IPC_TEST_HELPER)
 	@echo "test-ci: ok (native Quickshell and Omarchy shell fixtures excluded)"
 
-test: $(BIN_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TEST) $(SIGNAL_TEST_TARGET) $(IDENTITY_GUARD_TEST_TARGET) $(TOX_RELAY_RETRY_TEST_TARGET) $(TOX_NAME_TEST_TARGET) $(BIN_IPC_TEST_HELPER) $(REINVITE_TEST_TARGET)
+test: $(BIN_TEST) $(BIN_STORE_APPEND_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TEST) $(SIGNAL_TEST_TARGET) $(IDENTITY_GUARD_TEST_TARGET) $(TOX_RELAY_RETRY_TEST_TARGET) $(TOX_NAME_TEST_TARGET) $(BIN_IPC_TEST_HELPER) $(REINVITE_TEST_TARGET)
 	./$(BIN_TEST)
+	./$(BIN_STORE_APPEND_TEST)
 	./$(BIN_SPOOL_TEST)
 	./$(BIN_FILE_TRANSFER_TEST)
 	./$(BIN_AV_STATE_TEST)
@@ -410,7 +420,7 @@ verify-8: test arch helper
 	@echo "verify-8: ok"
 
 clean:
-	rm -f $(BIN_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TEST) \
+	rm -f $(BIN_TEST) $(BIN_STORE_APPEND_TEST) $(BIN_SPOOL_TEST) $(BIN_FILE_TRANSFER_TEST) $(BIN_AV_STATE_TEST) \
 		$(BIN_RATCHET_PREKEY_TEST) $(BIN_IDENTITY_GUARD_TEST) \
 		$(BIN_TOX_RELAY_RETRY_TEST) $(BIN_TOX_NAME_TEST) $(BIN_TOX_NAME_IPC_HELPER) \
 		$(BIN_IPC_TEST_HELPER) \

--- a/docs/CURRENT.md
+++ b/docs/CURRENT.md
@@ -2,6 +2,10 @@
 
 This page is the current product and release snapshot. Completed phase and follow-up history lives in the [stage notes](stages/README.md).
 
+## Unreleased branch work
+
+- History append now checks flush, file sync, close, and bottom-up directory sync before returning success and publishing the message ID in its index. Failures remain ambiguous and are not safe-resend signals. See [history append durability](stages/history-append-durability.md) for tests and outstanding native validation. This is branch work, not a released capability.
+
 ## Snapshot
 
 - **Project:** OmaQ, plugin id `hancore.omaq`

--- a/docs/stages/README.md
+++ b/docs/stages/README.md
@@ -37,3 +37,7 @@ The live product and release snapshot is [`../CURRENT.md`](../CURRENT.md).
 | [`safe-source-install.md`](safe-source-install.md) | External first-install build, atomic placement, controlled discovery, and enablement |
 
 Together, these notes record what landed, how the work was verified, measured RSS where relevant, and what remained outside each iteration. No note means the planned phase did not finish. Never add keys, complete Tox identifiers, or real chat logs.
+
+## Unreleased branch work
+
+- [History append durability](history-append-durability.md): checked file and directory sync before append success; native validation outstanding.

--- a/docs/stages/history-append-durability.md
+++ b/docs/stages/history-append-durability.md
@@ -1,0 +1,35 @@
+# History append durability — unreleased
+
+Base: `33f3b8d5b84b34e7a96dbd373286487de9afedd3`; branch `fix/history-append-sync`.
+
+## Behavior
+
+`omaq_store_append` checks writing, `fflush`, file `fsync`, and `fclose`. After closing, it syncs the conversation directory, history directory, and existing home directory, bottom-up. Only then does it publish the message ID to the in-memory index and return success. Directory access uses the existing descriptor-based no-follow traversal.
+
+All three directories are synced on every successful append. A prior failed directory sync can leave an existing but uncommitted name, so testing only whether a directory was just created would miss retries. This covers first history creation and the existing 2 MiB rotation rename without changing paths, JSONL format, permissions, or retention.
+
+Failure may leave complete or partial bytes and may occur after rotation. It is not rollback or permission to resend automatically. This change does not make Ratchet state and history transactional, alter rewrite/clear operations, encrypt local history, or establish remote delivery. Success relies on the filesystem and device honoring sync requests; the tests are not power-loss certification. The home directory is an existing caller-owned prerequisite.
+
+## Verification on 2026-09-09
+
+- `make PKG_CONFIG=false tests/store_append_test` and `ASAN_OPTIONS=detect_leaks=0 ./tests/store_append_test`: passed with AddressSanitizer and UndefinedBehaviorSanitizer. LeakSanitizer is disabled because this environment does not support its process inspection.
+- Covers append, first creation, permissions, child-process reopen, rotation, descriptor closure, and 15 injected failures/retries: write, flush, file sync, close, each of three directory syncs on fresh/existing history, plus directory sync failure after rotation. Failure tests model loss of unconfirmed bytes; they do not model an actual filesystem crash.
+- The same focused test compiled against the base `store.c` fails its successful-append sync assertion, demonstrating regression sensitivity.
+- `make PKG_CONFIG=false arch` and `./tests/no-signal-build.sh`: passed.
+- Full `make PKG_CONFIG=false test`: blocked at existing avatar decoder-dependent unused-function errors with image development dependencies unavailable.
+- `make PKG_CONFIG=false helper`: blocked by required Signal dependency. `phase2.sh` and `phase8.sh`: report no helper.
+- `qmllint`, `omarchy`, and `pkg-config` are unavailable. Native Omarchy validation and full CI remain outstanding; no QML changed.
+- Independent code review found no blocking defects; its suggested rotation failure test was added.
+
+The focused test uses GNU linker wrapping for deterministic libc failures. Only this test target disables fortified `fprintf` substitution so wrapping works; production hardening flags remain unchanged. The target is included in `test`, `test-ci`, and `clean`.
+
+## Latency and remaining acceptance
+
+One optimized local probe used 1,000 sequential appends with 256-byte synthetic text and unique IDs on container overlayfs. No rotation occurred in this probe.
+
+| Revision | Mean | Median | p95 | Maximum |
+|---|---:|---:|---:|---:|
+| Base | 18.7 µs | 14.0 µs | 21.6 µs | 705.8 µs |
+| Patch | 26.6 µs | 23.2 µs | 37.1 µs | 748.9 µs |
+
+These measurements establish local overhead only. Four synchronous sync calls per append may stall the networking helper on slower storage. Before merge, run full CI and the documented native gates on supported Arch/Omarchy, measure append p95 and worst-case helper responsiveness on actual storage, and exercise sustained direct/group text and rotation with synthetic identities. Any batching or asynchronous persistence design is a separate change.

--- a/helper/store.c
+++ b/helper/store.c
@@ -160,6 +160,20 @@ static int fsync_dir(const char *path)
 	return rc;
 }
 
+/* Use the same no-follow directory traversal as history file access. */
+static int fsync_parent(const char *path)
+{
+	char base[NAME_MAX + 1];
+	int fd = open_parent_dir(path, base, sizeof(base));
+	int rc;
+
+	if (fd < 0)
+		return -1;
+	rc = fsync(fd);
+	close(fd);
+	return rc;
+}
+
 static int mkdir_p(const char *path)
 {
 	if (mkdir(path, 0700) == 0 || errno == EEXIST)
@@ -1174,6 +1188,7 @@ int omaq_store_append(const char *home, const char *conv_id, const char *line)
 	char root[512];
 	FILE *f;
 	struct stat st;
+	int failed;
 
 	if (!line || strchr(line, '\n'))
 		return -1;
@@ -1201,11 +1216,17 @@ int omaq_store_append(const char *home, const char *conv_id, const char *line)
 		fclose(f);
 		return -1;
 	}
-	if (fprintf(f, "%s\n", line) < 0) {
-		fclose(f);
-		return -1;
-	}
+	failed = fprintf(f, "%s\n", line) < 0;
+	if (!failed && (fflush(f) != 0 || fsync(fileno(f)) != 0))
+		failed = 1;
 	if (fclose(f) != 0)
+		failed = 1;
+	if (failed)
+		return -1;
+	/* Sync bottom-up, including on retries after a failed directory sync.
+	 * Existing names can still be uncommitted from that earlier attempt. */
+	if (fsync_parent(path) != 0 || fsync_parent(dir) != 0 ||
+	    fsync_parent(root) != 0)
 		return -1;
 	{
 		char id[97];

--- a/helper/store.h
+++ b/helper/store.h
@@ -10,7 +10,10 @@ typedef struct {
 	char id[97];
 } omaq_store_message_id;
 
-/* Only this module opens history files. */
+/* Only this module opens history files.
+ * Append succeeds after flushing/syncing the file and its directory entries.
+ * Failure can leave bytes on disk; it is not a rollback or a safe-resend signal.
+ * This does not transact Ratchet state, history rewrites, or remote delivery. */
 
 int omaq_store_append(const char *home, const char *conv_id, const char *line);
 /* Removes current and rotated history for exactly one conversation. */

--- a/tests/store_append_test.c
+++ b/tests/store_append_test.c
@@ -1,0 +1,225 @@
+#define _DEFAULT_SOURCE
+#include "../helper/store.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+enum fault { NONE, WRITE, FLUSH, FILE_SYNC, CLOSE, DIR_SYNC_1, DIR_SYNC_2, DIR_SYNC_3 };
+static enum fault fault;
+static int armed, triggered, file_fd, directory_syncs, file_syncs, flushed;
+static char home[256], history[320], conversation[384], path[448], rotated[452];
+static const char *first = "{\"id\":\"first\",\"text\":\"hello\"}";
+static const char *second = "{\"id\":\"second\",\"text\":\"world\"}";
+
+int __real_fflush(FILE *);
+int __real_fsync(int);
+int __real_fclose(FILE *);
+
+static int inject(enum fault point)
+{
+	if (!armed || fault != point || triggered)
+		return 0;
+	triggered = 1;
+	errno = EIO;
+	return 1;
+}
+
+int __wrap_fprintf(FILE *f, const char *format, ...)
+{
+	va_list args;
+	int rc;
+
+	if (armed)
+		file_fd = fileno(f);
+	if (inject(WRITE))
+		return -1;
+	va_start(args, format);
+	rc = vfprintf(f, format, args);
+	va_end(args);
+	return rc;
+}
+
+int __wrap_fflush(FILE *f)
+{
+	if (inject(FLUSH))
+		return EOF;
+	int rc = __real_fflush(f);
+	if (armed && rc == 0)
+		flushed = 1;
+	return rc;
+}
+
+int __wrap_fsync(int fd)
+{
+	struct stat st, expected;
+
+	if (!armed)
+		return __real_fsync(fd);
+	assert(fstat(fd, &st) == 0);
+	if (S_ISREG(st.st_mode)) {
+		assert(flushed);
+		file_syncs++;
+		if (inject(FILE_SYNC))
+			return -1;
+	} else {
+		const char *parents[] = { conversation, history, home };
+		assert(S_ISDIR(st.st_mode));
+		assert(file_syncs == 1 && directory_syncs < 3);
+		assert(stat(parents[directory_syncs], &expected) == 0);
+		assert(st.st_dev == expected.st_dev && st.st_ino == expected.st_ino);
+		directory_syncs++;
+		if (inject((enum fault)(DIR_SYNC_1 + directory_syncs - 1)))
+			return -1;
+	}
+	return __real_fsync(fd);
+}
+
+int __wrap_fclose(FILE *f)
+{
+	int rc = __real_fclose(f);
+	if (inject(CLOSE))
+		return EOF;
+	return rc;
+}
+
+static void setup(void)
+{
+	strcpy(home, "/tmp/omaq-append-test-XXXXXX");
+	assert(mkdtemp(home));
+	snprintf(history, sizeof(history), "%s/history", home);
+	snprintf(conversation, sizeof(conversation), "%s/c1", history);
+	snprintf(path, sizeof(path), "%s/messages.jsonl", conversation);
+	snprintf(rotated, sizeof(rotated), "%s.1", path);
+}
+
+static void cleanup(void)
+{
+	armed = 0;
+	omaq_store_message_index_reset();
+	assert(omaq_store_clear(home, "c1") == 0);
+	assert(rmdir(history) == 0);
+	assert(rmdir(home) == 0);
+}
+
+static int append(const char *line, enum fault point)
+{
+	fault = point;
+	triggered = file_syncs = directory_syncs = flushed = 0;
+	file_fd = -1;
+	armed = 1;
+	int rc = omaq_store_append(home, "c1", line);
+	armed = 0;
+	assert(file_fd >= 0);
+	errno = 0;
+	assert(fcntl(file_fd, F_GETFD) == -1 && errno == EBADF);
+	if (point == NONE) {
+		assert(rc == 0 && file_syncs == 1 && directory_syncs == 3);
+	} else {
+		assert(triggered && rc == -1);
+	}
+	return rc;
+}
+
+static void check_mode(const char *name, mode_t expected)
+{
+	struct stat st;
+	assert(stat(name, &st) == 0 && (st.st_mode & 0777) == expected);
+}
+
+static void test_append_and_reopen(void)
+{
+	char *out = NULL;
+	size_t size;
+	setup();
+	append(first, NONE);
+	append(second, NONE);
+	check_mode(history, 0700);
+	check_mode(conversation, 0700);
+	check_mode(path, 0600);
+	pid_t child = fork();
+	assert(child >= 0);
+	if (child == 0) {
+		omaq_store_message_index_reset();
+		assert(omaq_store_tail(home, "c1", 2, &out, &size) == 0);
+		assert(strstr(out, first) && strstr(out, second));
+		assert(omaq_store_message_id_used(home, "c1", "first") == 1);
+		free(out);
+		_exit(0);
+	}
+	int status;
+	assert(waitpid(child, &status, 0) == child);
+	assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+	cleanup();
+}
+
+static void test_failure(enum fault point, int fresh)
+{
+	setup();
+	if (!fresh) {
+		append(first, NONE);
+		assert(omaq_store_message_id_used(home, "c1", "first") == 1);
+	}
+	append(second, point);
+	/* A failure is ambiguous: bytes may already exist. Simulate losing the
+	 * unconfirmed append, then ensure it was not published in the warm index. */
+	assert(truncate(path, fresh ? 0 : (off_t)strlen(first) + 1) == 0);
+	assert(omaq_store_message_id_used(home, "c1", "second") == 0);
+	/* Retry must sync even directories created by the failed attempt. */
+	append(second, NONE);
+	assert(omaq_store_message_id_used(home, "c1", "second") == 1);
+	cleanup();
+}
+
+static void test_rotation(enum fault point)
+{
+	setup();
+	append(first, NONE);
+	int fd = open(path, O_WRONLY | O_APPEND);
+	assert(fd >= 0);
+	/* Valid JSON lines fill the existing file to the 2 MiB rotation boundary. */
+	char block[8192];
+	memset(block, ' ', sizeof(block));
+	memcpy(block, "{\"id\":\"padding\"}", strlen("{\"id\":\"padding\"}"));
+	block[sizeof(block) - 1] = '\n';
+	for (int i = 0; i < 256; i++)
+		assert(write(fd, block, sizeof(block)) == (ssize_t)sizeof(block));
+	assert(close(fd) == 0);
+	append(second, point);
+	if (point != NONE) {
+		/* Model loss of the unconfirmed active record after the rename. */
+		assert(truncate(path, 0) == 0);
+		append(second, NONE);
+	}
+	struct stat st;
+	assert(stat(rotated, &st) == 0 && st.st_size >= 2 * 1024 * 1024);
+	assert(stat(path, &st) == 0 && st.st_size == (off_t)strlen(second) + 1);
+	check_mode(rotated, 0600);
+	check_mode(path, 0600);
+	char *out = NULL;
+	size_t size;
+	assert(omaq_store_tail(home, "c1", 1, &out, &size) == 0);
+	assert(strstr(out, second));
+	free(out);
+	cleanup();
+}
+
+int main(void)
+{
+	test_append_and_reopen();
+	for (int f = WRITE; f <= DIR_SYNC_3; f++) {
+		test_failure((enum fault)f, 0);
+		test_failure((enum fault)f, 1);
+	}
+	test_rotation(NONE);
+	test_rotation(DIR_SYNC_1);
+	puts("store_append_test: ok (append/reopen, rotation, 15 injected failures/retries)");
+	return 0;
+}


### PR DESCRIPTION
This PR makes chat-history append success mean the file and its directory entries have been explicitly synced.

Previously, omaq_store_append returned success after closing the stream, without a persistence barrier. That left recently appended history vulnerable to loss after a system crash or power failure.

The change:

* Checks writing, flushing, file sync and close, propagating failures.
* Syncs the conversation, history and home directories, covering first creation, rotation and retries after failed syncs.
* Updates the in-memory message index only after those steps succeed.

The JSONL format, paths, permissions and rotation policy stay unchanged.

Validation includes a passing ASan/UBSan test covering creation, reopening, rotation and 15 injected failures and retries. The same test fails against the original implementation at the missing-sync assertion. Architecture and no-Signal build checks also pass. A separate Codex review found no blocking defects.

Full integration and native Arch/Omarchy validation remain outstanding because the required dependencies are unavailable in this environment. LeakSanitizer was disabled.

There is a performance trade-off: four synchronous sync calls per append. A 1,000-message container benchmark measured median append latency rising from 14.0 µs to 23.2 µs. Actual storage latency and helper responsiveness still need checking on Omarchy.

A failed append can leave bytes behind. This change provides no rollback, safe automatic resend or transaction spanning Ratchet state and history. The tests verify ordering and failure handling, not survival of an actual power cut.

Built with Codex. Implementation notes and validation details are in docs/stages/history-append-durability.md.

I’ve kept this first contribution focused on history persistence. Feedback on the sync strategy, particularly its effect on helper responsiveness on real hardware, would be useful.